### PR TITLE
Fix admin login dynamic route and prisma usage

### DIFF
--- a/app/admin/login/page.tsx
+++ b/app/admin/login/page.tsx
@@ -1,5 +1,7 @@
 "use client"
 
+export const dynamic = "force-dynamic"
+
 import { useState, type FormEvent, useEffect } from "react"
 import { signIn, getSession } from "next-auth/react"
 import { useRouter, useSearchParams } from "next/navigation"

--- a/app/api/admin/categories/route.ts
+++ b/app/api/admin/categories/route.ts
@@ -1,7 +1,5 @@
 import { type NextRequest, NextResponse } from "next/server"
-import { PrismaClient } from "@prisma/client"
-
-const prisma = new PrismaClient()
+import { prisma } from "@/lib/prisma"
 
 // GET /api/admin/categories - List all categories
 export async function GET() {


### PR DESCRIPTION
## Summary
- mark admin login page as dynamic to avoid static optimization
- use shared Prisma client in admin categories API

## Testing
- `npm run codex:setup`
- `node scripts/fix-admin-login-final.js` *(fails: Can't reach database server)*
- `node scripts/test-db-connection.js` *(fails: Can't reach database server)*
- `npm run lint` *(interactive prompt)*
- `npm run build` *(fails to download swc due to network)*

------
https://chatgpt.com/codex/tasks/task_e_685dad8c01b483308b635f405229ce4a