### PR TITLE
Fix schema field usage and auth return

### DIFF
--- a/app/admin/equipamentos/novo/page.tsx
+++ b/app/admin/equipamentos/novo/page.tsx
@@ -27,7 +27,7 @@ interface FormData {
   pricePerDay: number
   categoryId: string
   images: string[]
-  isAvailable: boolean
+  available: boolean
   specifications?: Record<string, string>
 }
 
@@ -41,7 +41,7 @@ export default function NovoEquipamento() {
     pricePerDay: 0,
     categoryId: "",
     images: [],
-    isAvailable: true,
+    available: true,
     specifications: {},
   })
   const [specKey, setSpecKey] = useState("")
@@ -222,11 +222,13 @@ export default function NovoEquipamento() {
               </div>
               <div className="flex items-center space-x-3 pt-6">
                 <Switch
-                  id="isAvailable"
-                  checked={formData.isAvailable}
-                  onCheckedChange={(checked) => setFormData((prev) => ({ ...prev, isAvailable: checked }))}
+                  id="available"
+                  checked={formData.available}
+                  onCheckedChange={(checked) =>
+                    setFormData((prev) => ({ ...prev, available: checked }))
+                  }
                 />
-                <Label htmlFor="isAvailable" className="cursor-pointer">
+                <Label htmlFor="available" className="cursor-pointer">
                   Equipamento disponível para locação
                 </Label>
               </div>

--- a/app/admin/equipamentos/page.tsx
+++ b/app/admin/equipamentos/page.tsx
@@ -23,7 +23,7 @@ interface Equipment {
   name: string
   description: string
   pricePerDay: number
-  isAvailable: boolean
+  available: boolean
   images: string[]
   category: {
     id: string
@@ -83,7 +83,7 @@ export default function EquipmentsPage() {
       params.append("limit", itemsPerPage.toString())
       if (search) params.append("search", search)
       if (selectedCategory && selectedCategory !== "all") params.append("categoryId", selectedCategory)
-      if (availabilityFilter && availabilityFilter !== "all") params.append("isAvailable", availabilityFilter)
+      if (availabilityFilter && availabilityFilter !== "all") params.append("available", availabilityFilter)
 
       console.log(`[EquipmentsPage] Fetching: /api/admin/equipments?${params.toString()}`)
       const response = await fetch(`/api/admin/equipments?${params.toString()}`)
@@ -370,15 +370,15 @@ export default function EquipmentsPage() {
                     <TableCell className="text-sm">R$ {equipment.pricePerDay.toFixed(2)}</TableCell>
                     <TableCell>
                       <Badge
-                        variant={equipment.isAvailable ? "default" : "destructive"}
+                        variant={equipment.available ? "default" : "destructive"}
                         className={cn(
                           "text-xs",
-                          equipment.isAvailable
+                          equipment.available
                             ? "bg-green-100 text-green-700 border-green-300 dark:bg-green-700 dark:text-green-100 dark:border-green-500"
                             : "bg-red-100 text-red-700 border-red-300 dark:bg-red-700 dark:text-red-100 dark:border-red-500",
                         )}
                       >
-                        {equipment.isAvailable ? "Disponível" : "Indisponível"}
+                        {equipment.available ? "Disponível" : "Indisponível"}
                       </Badge>
                     </TableCell>
                     <TableCell className="hidden lg:table-cell text-center text-sm">

--- a/app/api/equipments/route.ts
+++ b/app/api/equipments/route.ts
@@ -34,8 +34,8 @@ export async function GET() {
             id: "mock-cat-1",
             name: "Equipamentos",
           },
-          reviews: [],
-        },
+          // TODO: implementar reviews
+      },
       ]
       return NextResponse.json(mockEquipments)
     }
@@ -66,7 +66,7 @@ export async function GET() {
           id: equipment.category.id,
           name: equipment.category.name,
         },
-        reviews: [],
+        // TODO: implementar reviews
       }
 
       console.log(`Equipamento formatado:`, {
@@ -96,7 +96,7 @@ export async function GET() {
           id: "fallback-cat-1",
           name: "Equipamentos",
         },
-        reviews: [],
+        // TODO: implementar reviews
       },
     ]
 

--- a/app/equipamentos/[id]/page.tsx
+++ b/app/equipamentos/[id]/page.tsx
@@ -32,10 +32,7 @@ export default async function EquipmentDetailPage({ params }: Props) {
     where: { id: params.id },
     include: {
       category: true,
-      reviews: {
-        orderBy: { createdAt: "desc" },
-        take: 5,
-      },
+      // TODO: implementar reviews
     },
   })
 

--- a/app/orcamento/page.tsx
+++ b/app/orcamento/page.tsx
@@ -25,7 +25,7 @@ interface Equipment {
   category: {
     name: string
   }
-  isAvailable: boolean
+  available: boolean
 }
 
 interface SelectedEquipment extends Equipment {
@@ -66,8 +66,8 @@ function QuotePage() {
     try {
       const response = await fetch(`/api/equipments`)
       const data = await response.json()
-      const equipments = Array.isArray(data) ? data : []
-      const equipment = equipments.find((eq: any) => eq.id === equipmentId)
+      const equipments: Equipment[] = Array.isArray(data) ? data : []
+      const equipment = equipments.find((eq) => eq.id === equipmentId)
 
       if (equipment) {
         const price = Number(equipment.pricePerDay) || 0

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -59,7 +59,7 @@ export const authOptions: NextAuthOptions = {
             email: user.email,
             name: user.name,
             role: user.role,
-          } as any
+          }
         } catch (error) {
           console.error("💥 [AUTH] Erro:", error)
           return null


### PR DESCRIPTION
## Summary
- update equipment interfaces to use `available` field
- sync admin equipment list filtering with API
- remove unfinished reviews access on equipment detail and API
- type fetch logic in quote page
- return typed user in `authorize`

## Testing
- `npx tsc --noEmit` *(fails: numerous existing errors)*
- `npm run build` *(fails: build errors and blocked network requests)*

------
https://chatgpt.com/codex/tasks/task_e_685ebe20cda08330904d961898c7db21