### PR TITLE
Fix equipment _count selection

### DIFF
--- a/app/api/admin/equipments/route.ts
+++ b/app/api/admin/equipments/route.ts
@@ -67,8 +67,8 @@ export async function GET(request: NextRequest) {
         category: true,
         _count: {
           select: {
-            reviews: true,
             quoteItems: true,
+            rental_items: true,
           },
         },
       },


### PR DESCRIPTION
## Summary
- remove invalid `reviews` count from admin equipment listing
- count `quoteItems` and `rental_items` instead

## Testing
- `npm run lint` *(fails: asks for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_685f1030af408330b6d8a9ba1ae43827