### PR TITLE
Fix ESLint warnings

### DIFF
--- a/app/api/admin/categories/route.ts
+++ b/app/api/admin/categories/route.ts
@@ -50,7 +50,7 @@ export async function POST(request: NextRequest) {
     let body
     try {
       body = await request.json()
-    } catch (err) {
+    } catch (_err) {
       return NextResponse.json({ error: "JSON inválido" }, { status: 400 })
     }
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -47,7 +47,7 @@ export default defineConfig([
       "react/display-name": "off",
       "react/react-in-jsx-scope": "off",
       "react/jsx-uses-react": "off",
-      "no-unused-vars": ["warn", { argsIgnorePattern: "^_" }],
+      "no-unused-vars": ["warn", { argsIgnorePattern: "^_", caughtErrorsIgnorePattern: "^_" }],
       "no-undef": "error",
     },
   },

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "seed": "tsx prisma/seed.ts",
     "codex:setup": "npm install && npx prisma generate && echo 'Ambiente inicializado com sucesso!'"
   },
+  "eslintIgnore": ["**/*.css"],
   "dependencies": {
     "@auth/core": "latest",
     "@edge-runtime/vm": "latest",


### PR DESCRIPTION
## Summary
- ignore CSS files in ESLint
- handle unused error variable in admin categories API
- allow underscore prefixed catch params in lint config

## Testing
- `pnpm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685f40b97efc8330b584428acba31fe5