### PR TITLE
Fix category creation validation

### DIFF
--- a/app/admin/categorias/page.tsx
+++ b/app/admin/categorias/page.tsx
@@ -101,8 +101,12 @@ export default function AdminCategoriesPage() {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
-    if (!formData.name) {
+    if (!formData.name.trim()) {
       toast.error("O nome da categoria é obrigatório.")
+      return
+    }
+    if (!formData.icon || !formData.iconColor || !formData.bgColor || !formData.fontColor) {
+      toast.error("Preencha todos os campos obrigatórios.")
       return
     }
     setIsSubmitting(true)


### PR DESCRIPTION
## Summary
- validate category payload with Zod in route
- log body only in dev mode
- prevent submission if the category name is empty on AdminCategories page

## Testing
- `pnpm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685f47bdf4a883309882ee8b45e7a29f