### PR TITLE
Fix Category API UUID generation

### DIFF
--- a/app/api/admin/categories/route.ts
+++ b/app/api/admin/categories/route.ts
@@ -1,6 +1,7 @@
 import { type NextRequest, NextResponse } from "next/server"
 import { Prisma } from "@prisma/client"
 import { z } from "zod"
+import crypto from "node:crypto"
 import { prisma } from "@/lib/prisma"
 
 function slugify(text: string) {
@@ -101,6 +102,7 @@ export async function POST(request: NextRequest) {
 
     const category = await prisma.category.create({
       data: {
+        id: crypto.randomUUID(),
         name: name.trim(),
         description: description?.trim() || null,
         icon: icon?.trim() || null,


### PR DESCRIPTION
## Summary
- ensure valid UUID generation when creating categories

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685f5026dd8483309d143dcf832b8fc5