### PR TITLE
Fix modals accessibility and schema

### DIFF
--- a/app/ClientLayout.tsx
+++ b/app/ClientLayout.tsx
@@ -26,7 +26,8 @@ export default function ClientLayout({
   return (
     <html lang="pt-BR" className={inter.variable}>
       <head>
-        <link rel="icon" href="/favicon.ico" />
+        <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
+        <link rel="shortcut icon" href="/favicon.svg" type="image/svg+xml" />
         <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
         <meta name="theme-color" content="#334155" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/app/admin/categorias/page.tsx
+++ b/app/admin/categorias/page.tsx
@@ -306,11 +306,11 @@ export default function AdminCategoriesPage() {
 
       <Dialog open={isFormDialogOpen} onOpenChange={setIsFormDialogOpen}>
         <DialogContent
-          className="max-w-md sm:max-w-lg w-[90vw] sm:w-full max-h-[90vh] overflow-y-auto p-6"
+          className="max-w-md sm:max-w-lg w-[90vw] sm:w-full max-h-[90vh] overflow-hidden p-0 flex flex-col"
           aria-labelledby="category-dialog-title"
           aria-describedby="category-dialog-desc"
         >
-          <DialogHeader>
+          <DialogHeader className="p-6 pb-4 border-b">
             <DialogTitle id="category-dialog-title" className="text-lg sm:text-xl">
               {editingCategory ? "Editar Categoria" : "Nova Categoria"}
             </DialogTitle>
@@ -318,7 +318,10 @@ export default function AdminCategoriesPage() {
               Preencha os dados da categoria.
             </DialogDescription>
           </DialogHeader>
-          <form onSubmit={handleSubmit} className="space-y-4 sm:space-y-6 py-4">
+          <form
+            onSubmit={handleSubmit}
+            className="space-y-4 sm:space-y-6 overflow-y-auto px-6 pb-6 flex-grow"
+          >
             <div>
               <Label htmlFor="cat-name" className="text-sm font-medium">
                 Nome da Categoria *

--- a/app/admin/orcamentos/page.tsx
+++ b/app/admin/orcamentos/page.tsx
@@ -404,15 +404,25 @@ export default function AdminQuotesPage() {
                                 <Eye className="h-4 w-4" />
                               </Button>
                             </DialogTrigger>
-                            <DialogContent className="max-w-6xl max-h-[90vh] overflow-y-auto">
-                              <DialogHeader>
-                                <DialogTitle className="flex items-center gap-2">
+                            <DialogContent
+                              className="max-w-6xl w-[90vw] sm:w-full max-h-[90vh] overflow-hidden p-0 flex flex-col"
+                              aria-labelledby="quote-dialog-title"
+                              aria-describedby="quote-dialog-desc"
+                            >
+                              <DialogHeader className="p-6 pb-4 border-b">
+                                <DialogTitle
+                                  id="quote-dialog-title"
+                                  className="flex items-center gap-2"
+                                >
                                   <FileText className="h-5 w-5" />
                                   Detalhes do Orçamento #{selectedQuote?.id.slice(-8)}
                                 </DialogTitle>
+                                <DialogDescription id="quote-dialog-desc">
+                                  Informações completas do orçamento.
+                                </DialogDescription>
                               </DialogHeader>
                               {selectedQuote && (
-                                <div className="space-y-6">
+                                <div className="space-y-6 overflow-y-auto px-6 pb-6 flex-grow">
                                   {/* Customer & Project Info */}
                                   <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
                                     <Card>

--- a/app/api/admin/categories/route.ts
+++ b/app/api/admin/categories/route.ts
@@ -19,7 +19,7 @@ const CategorySchema = z
   .object({
     name: z.string().min(1, "O nome da categoria é obrigatório"),
     description: z.string().optional(),
-    icon: z.string().min(1, "Ícone é obrigatório"),
+    icon: z.string().optional().nullable(),
     iconColor: z.string().min(1, "Cor do ícone é obrigatória"),
     bgColor: z.string().min(1, "Cor de fundo é obrigatória"),
     fontColor: z.string().min(1, "Cor da fonte é obrigatória"),
@@ -67,6 +67,8 @@ export async function POST(request: NextRequest) {
     } catch (_err) {
       return NextResponse.json({ error: "JSON inválido" }, { status: 400 })
     }
+
+    if (!raw.icon) delete raw.icon
 
     if (process.env.NODE_ENV !== "production") {
       console.log("[CATEGORY_PAYLOAD]", raw)

--- a/components/admin/admin-sidebar.tsx
+++ b/components/admin/admin-sidebar.tsx
@@ -64,7 +64,7 @@ export default function AdminSidebar() {
               alt="GB Locações Logo"
               width={32}
               height={32}
-              className="flex-shrink-0"
+              className="flex-shrink-0 w-auto h-auto"
             />
             <div className="flex flex-col min-w-0">
               <h2 className="text-base sm:text-lg font-bold text-white truncate">GB Locações</h2>
@@ -74,7 +74,13 @@ export default function AdminSidebar() {
         )}
         {isSidebarCollapsed && (
           <Link href="/" className="flex items-center justify-center w-full py-2">
-            <Image src="/placeholder-logo.svg" alt="GB Locações Logo" width={32} height={32} />
+            <Image
+              src="/placeholder-logo.svg"
+              alt="GB Locações Logo"
+              width={32}
+              height={32}
+              className="w-auto h-auto"
+            />
           </Link>
         )}
       </div>
@@ -131,7 +137,13 @@ export default function AdminSidebar() {
       {/* Mobile Header & Hamburger */}
       <header className="md:hidden sticky top-0 z-40 bg-slate-900 text-white p-3 flex items-center justify-between border-b border-slate-700">
         <Link href="/admin/dashboard" className="flex items-center gap-2 min-w-0">
-          <Image src="/placeholder-logo.svg" alt="GB Locações Logo" width={24} height={24} className="flex-shrink-0" />
+          <Image
+            src="/placeholder-logo.svg"
+            alt="GB Locações Logo"
+            width={24}
+            height={24}
+            className="flex-shrink-0 w-auto h-auto"
+          />
           <span className="font-semibold text-sm truncate">GB Admin</span>
         </Link>
         <Button

--- a/components/ui/command.tsx
+++ b/components/ui/command.tsx
@@ -26,7 +26,13 @@ Command.displayName = CommandPrimitive.displayName
 const CommandDialog = ({ children, ...props }: DialogProps) => {
   return (
     <Dialog {...props}>
-      <DialogContent className="overflow-hidden p-0 shadow-lg">
+      <DialogContent
+        className="overflow-hidden p-0 shadow-lg"
+        aria-labelledby="command-dialog-title"
+      >
+        <DialogHeader className="sr-only">
+          <DialogTitle id="command-dialog-title">Comandos</DialogTitle>
+        </DialogHeader>
         <Command className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
           {children}
         </Command>

--- a/components/ui/emoji-picker.tsx
+++ b/components/ui/emoji-picker.tsx
@@ -72,12 +72,19 @@ export function EmojiPicker({ isOpen, onClose, onSelect, currentEmoji }: EmojiPi
 
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent className="max-w-md">
+      <DialogContent
+        className="max-w-md"
+        aria-labelledby="emoji-picker-title"
+        aria-describedby="emoji-picker-desc"
+      >
         <DialogHeader>
-          <DialogTitle className="flex items-center gap-2">
+          <DialogTitle id="emoji-picker-title" className="flex items-center gap-2">
             <Smile className="h-5 w-5" />
             Selecionar Emoji
           </DialogTitle>
+          <DialogDescription id="emoji-picker-desc">
+            Escolha um emoji para a categoria.
+          </DialogDescription>
         </DialogHeader>
 
         <div className="space-y-4">

--- a/components/ui/icon-picker.tsx
+++ b/components/ui/icon-picker.tsx
@@ -175,10 +175,13 @@ export function IconPicker({ value, color: initialColor, onSelect, isOpen, onClo
       <DialogContent
         className="max-w-2xl w-[90vw] sm:w-full max-h-[90vh] overflow-y-hidden p-0 flex flex-col"
         aria-labelledby="icon-picker-title"
+        aria-describedby="icon-picker-desc"
       >
         <DialogHeader className="p-6 pb-4 border-b">
           <DialogTitle id="icon-picker-title">Selecionar Ícone</DialogTitle>
-          <DialogDescription>Escolha um ícone da biblioteca e personalize a cor.</DialogDescription>
+          <DialogDescription id="icon-picker-desc">
+            Escolha um ícone da biblioteca e personalize a cor.
+          </DialogDescription>
         </DialogHeader>
 
         <div className="flex flex-col md:grid md:grid-cols-[280px_1fr] gap-0 flex-1 overflow-hidden">

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#334155"/>
+  <text x="16" y="23" text-anchor="middle" font-size="20" fill="white">GB</text>
+</svg>


### PR DESCRIPTION
## Summary
- allow categories without icon
- clean undefined icon before validating
- improve Dialog accessibility with titles/descriptions
- limit modal height and enable inner scrolling
- keep sidebar logo proportions
- use SVG favicon to avoid binary diff

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68614fce61908330b0907250e5ca1d67