### PR TITLE
Fix admin UI overflow issues and icon picker layout

### DIFF
--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -66,8 +66,8 @@ function AdminLayoutContent({ children }: AdminLayoutProps) {
       <AdminSidebar />
       <div className="flex flex-1 flex-col overflow-hidden min-w-0 overflow-x-hidden">
         <AdminHeader />
-        <main className="w-full max-w-screen overflow-x-hidden flex-1 overflow-y-auto bg-gray-50">
-          <div className="h-full min-h-0 max-h-[100vh] overflow-y-auto">{children}</div>
+        <main className="flex-1 overflow-y-auto overflow-x-hidden max-w-[100vw]">
+          {children}
         </main>
       </div>
     </div>

--- a/components/admin/admin-header.tsx
+++ b/components/admin/admin-header.tsx
@@ -10,8 +10,8 @@ export default function AdminHeader() {
   const { data: session } = useSession()
 
   return (
-    <header className="w-full sticky top-0 z-50 bg-white border-b">
-      <div className="mx-auto flex max-w-screen px-4 sm:px-6 lg:px-8 h-16 items-center justify-between overflow-x-hidden">
+    <header className="sticky top-0 z-50 bg-white border-b w-full overflow-hidden">
+      <div className="flex items-center justify-between px-4 sm:px-6 lg:px-8 h-16 w-full max-w-[100vw] overflow-hidden">
         <div className="flex items-center gap-2 sm:gap-4 min-w-0 flex-1">
           <Sheet>
             <SheetTrigger asChild>

--- a/components/ui/icon-picker.tsx
+++ b/components/ui/icon-picker.tsx
@@ -185,7 +185,7 @@ export function IconPicker({ value, color: initialColor, onSelect, isOpen, onClo
         </DialogHeader>
 
         <div className="flex flex-col md:grid md:grid-cols-[280px_1fr] gap-0 flex-1 overflow-hidden">
-          <div className="p-6 border-r flex flex-col gap-6 bg-muted/30 overflow-y-auto">
+          <div className="p-6 border-r flex flex-col gap-6 bg-muted/30">
             <div>
               <Label htmlFor="icon-color" className="mb-2 block font-medium text-sm">
                 Cor do Ícone
@@ -210,23 +210,26 @@ export function IconPicker({ value, color: initialColor, onSelect, isOpen, onClo
             </div>
 
             {selectedIcon && ICONS[selectedIcon as keyof typeof ICONS] && (
-              <div className="space-y-2">
-                <Label className="font-medium text-sm">Ícone Selecionado</Label>
-                <div className="p-4 border rounded-lg flex flex-col items-center justify-center gap-2 bg-background min-h-[120px]">
+              <div className="flex flex-col items-center gap-2 py-2">
+                <div className="p-2 border rounded-md bg-muted flex items-center justify-center w-20 h-20">
                   {React.createElement(ICONS[selectedIcon as keyof typeof ICONS], {
-                    size: 48,
+                    className: "w-10 h-10",
                     color: iconColor,
                     strokeWidth: 1.5,
                   })}
-                  <span className="text-xs text-muted-foreground">{selectedIcon}</span>
                 </div>
+                <span className="text-sm text-muted-foreground">{selectedIcon}</span>
+
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="mt-2"
+                  onClick={() => setSelectedIcon(undefined)}
+                >
+                  Limpar Seleção
+                </Button>
               </div>
             )}
-
-            <Button variant="outline" onClick={() => setSelectedIcon(undefined)} className="w-full text-sm">
-              <X className="h-4 w-4 mr-2" />
-              Limpar Seleção
-            </Button>
           </div>
 
           <div className="flex flex-col max-h-[500px] overflow-hidden">

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -6,6 +6,12 @@ body {
   font-family: Arial, Helvetica, sans-serif;
 }
 
+html,
+body {
+  overflow-x: hidden;
+  max-width: 100vw;
+}
+
 @layer utilities {
   .text-balance {
     text-wrap: balance;


### PR DESCRIPTION
## Summary
- tweak icon picker selected icon layout
- ensure admin header never overflows
- constrain admin layout to viewport width
- prevent horizontal scroll globally

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686167e9f90c8330b42f1b312400f990