### PR TITLE
Improve admin header layout

### DIFF
--- a/components/admin/admin-header.tsx
+++ b/components/admin/admin-header.tsx
@@ -15,10 +15,14 @@ export default function AdminHeader() {
         <div className="flex items-center gap-2 sm:gap-4 min-w-0 flex-1">
           <Sheet>
             <SheetTrigger asChild>
-              <Button variant="outline" size="icon" className="md:hidden h-9 w-9 sm:h-10 sm:w-10 bg-transparent">
-                <Menu className="h-4 w-4 sm:h-5 sm:w-5" />
-                <span className="sr-only">Abrir menu</span>
-              </Button>
+            <Button
+              variant="outline"
+              size="icon"
+              className="md:hidden h-9 w-9 sm:h-10 sm:w-10 bg-transparent flex-shrink-0"
+            >
+              <Menu className="h-4 w-4 sm:h-5 sm:w-5" />
+              <span className="sr-only">Abrir menu</span>
+            </Button>
           </SheetTrigger>
           <SheetContent side="left" className="flex flex-col p-0 w-64">
             <AdminSidebar />
@@ -34,11 +38,19 @@ export default function AdminHeader() {
         </div>
         </div>
         <div className="flex items-center gap-1 sm:gap-2 lg:gap-4 flex-shrink-0">
-          <Button variant="ghost" size="icon" className="rounded-full h-9 w-9 sm:h-10 sm:w-10 hidden sm:flex">
+          <Button
+            variant="ghost"
+            size="icon"
+            className="rounded-full h-9 w-9 sm:h-10 sm:w-10 hidden sm:flex flex-shrink-0"
+          >
             <Search className="h-4 w-4 sm:h-5 sm:w-5 text-gray-600" />
             <span className="sr-only">Buscar</span>
           </Button>
-          <Button variant="ghost" size="icon" className="rounded-full h-9 w-9 sm:h-10 sm:w-10 hidden sm:flex">
+          <Button
+            variant="ghost"
+            size="icon"
+            className="rounded-full h-9 w-9 sm:h-10 sm:w-10 hidden sm:flex flex-shrink-0"
+          >
           <Bell className="h-4 w-4 sm:h-5 sm:w-5 text-gray-600" />
           <span className="sr-only">Notificações</span>
         </Button>

--- a/components/admin/admin-sidebar.tsx
+++ b/components/admin/admin-sidebar.tsx
@@ -189,13 +189,13 @@ export default function AdminSidebar() {
           variant="ghost"
           size="icon"
           onClick={toggleSidebarCollapse}
-          className="absolute top-1/2 -right-3 lg:-right-4 transform -translate-y-1/2 bg-slate-800 hover:bg-slate-700 text-white rounded-full h-6 w-6 lg:h-8 lg:w-8 border-2 border-slate-900 shadow-lg"
+          className="absolute top-1/2 -right-3 lg:-right-4 transform -translate-y-1/2 bg-slate-800 hover:bg-slate-700 text-white rounded-full h-[20px] w-[20px] border-2 border-slate-900 shadow-lg"
           title={isSidebarCollapsed ? "Expandir sidebar" : "Recolher sidebar"}
         >
           {isSidebarCollapsed ? (
-            <ChevronsRight className="h-3 w-3 lg:h-4 lg:w-4" />
+            <ChevronsRight className="h-3 w-3" />
           ) : (
-            <ChevronsLeft className="h-3 w-3 lg:h-4 lg:w-4" />
+            <ChevronsLeft className="h-3 w-3" />
           )}
         </Button>
       </aside>


### PR DESCRIPTION
## Summary
- prevent header overflow by making the sidebar trigger and action buttons non-shrinking
- reduce sidebar collapse button size to 20x20

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68616b56d25083309d02a5fe09ad0b1d