### PR TITLE
Rebuild admin header

### DIFF
--- a/components/admin/admin-header.tsx
+++ b/components/admin/admin-header.tsx
@@ -10,47 +10,59 @@ export default function AdminHeader() {
   const { data: session } = useSession()
 
   return (
-    <header className="sticky top-0 z-50 bg-white border-b w-full overflow-hidden">
-      <div className="flex items-center justify-between px-4 sm:px-6 lg:px-8 h-16 w-full max-w-[100vw] overflow-hidden">
-        <div className="flex items-center gap-2 sm:gap-4 min-w-0 flex-1">
+    <header className="sticky top-0 z-50 w-full border-b bg-white">
+      <div className="flex items-center justify-between h-16 px-4 sm:px-6 lg:px-8 overflow-hidden max-w-full">
+        <div className="flex flex-1 items-center gap-2 sm:gap-4 min-w-0">
           <Sheet>
             <SheetTrigger asChild>
-              <Button variant="outline" size="icon" className="md:hidden h-9 w-9 sm:h-10 sm:w-10 bg-transparent">
-                <Menu className="h-4 w-4 sm:h-5 sm:w-5" />
+              <Button
+                variant="outline"
+                size="icon"
+                className="md:hidden h-[20px] w-[20px] p-0 bg-transparent flex-shrink-0"
+              >
+                <Menu className="h-3 w-3" />
                 <span className="sr-only">Abrir menu</span>
               </Button>
-          </SheetTrigger>
-          <SheetContent side="left" className="flex flex-col p-0 w-64">
-            <AdminSidebar />
-          </SheetContent>
-        </Sheet>
-        <div className="hidden md:flex items-center gap-2 text-base lg:text-lg font-semibold text-slate-700 min-w-0">
-          <Building className="h-5 w-5 lg:h-6 lg:w-6 text-orange-500 flex-shrink-0" />
-          <span className="truncate">Painel GB Locações</span>
-        </div>
-        <div className="md:hidden flex items-center gap-2 text-sm font-semibold text-slate-700 min-w-0">
-          <Building className="h-4 w-4 text-orange-500 flex-shrink-0" />
-          <span className="truncate">GB Admin</span>
-        </div>
+            </SheetTrigger>
+            <SheetContent side="left" className="flex flex-col w-64 p-0">
+              <AdminSidebar />
+            </SheetContent>
+          </Sheet>
+          <div className="hidden md:flex items-center gap-2 font-semibold text-slate-700 min-w-0">
+            <Building className="h-5 w-5 text-orange-500 flex-shrink-0" />
+            <span className="truncate">Painel GB Locações</span>
+          </div>
+          <div className="md:hidden flex items-center gap-2 font-semibold text-slate-700 min-w-0">
+            <Building className="h-4 w-4 text-orange-500 flex-shrink-0" />
+            <span className="truncate">GB Admin</span>
+          </div>
         </div>
         <div className="flex items-center gap-1 sm:gap-2 lg:gap-4 flex-shrink-0">
-          <Button variant="ghost" size="icon" className="rounded-full h-9 w-9 sm:h-10 sm:w-10 hidden sm:flex">
+          <Button
+            variant="ghost"
+            size="icon"
+            className="rounded-full h-9 w-9 sm:h-10 sm:w-10 hidden sm:flex flex-shrink-0"
+          >
             <Search className="h-4 w-4 sm:h-5 sm:w-5 text-gray-600" />
             <span className="sr-only">Buscar</span>
           </Button>
-          <Button variant="ghost" size="icon" className="rounded-full h-9 w-9 sm:h-10 sm:w-10 hidden sm:flex">
-          <Bell className="h-4 w-4 sm:h-5 sm:w-5 text-gray-600" />
-          <span className="sr-only">Notificações</span>
-        </Button>
-        <div className="flex items-center gap-1 sm:gap-2 min-w-0">
-          <UserCircle className="h-6 w-6 sm:h-7 sm:w-7 text-gray-500 flex-shrink-0" />
-          <div className="hidden sm:block min-w-0">
-            <p className="text-xs sm:text-sm font-medium text-gray-700 truncate max-w-24 lg:max-w-none">
-              {session?.user?.name || "Admin"}
-            </p>
-            {/* @ts-ignore */}
-            <p className="text-xs text-gray-500 truncate max-w-24 lg:max-w-none">{session?.user?.role}</p>
-          </div>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="rounded-full h-9 w-9 sm:h-10 sm:w-10 hidden sm:flex flex-shrink-0"
+          >
+            <Bell className="h-4 w-4 sm:h-5 sm:w-5 text-gray-600" />
+            <span className="sr-only">Notificações</span>
+          </Button>
+          <div className="flex items-center gap-1 sm:gap-2 min-w-0">
+            <UserCircle className="h-6 w-6 sm:h-7 sm:w-7 text-gray-500 flex-shrink-0" />
+            <div className="hidden sm:block min-w-0">
+              <p className="text-xs sm:text-sm font-medium text-gray-700 truncate max-w-24 lg:max-w-none">
+                {session?.user?.name || "Admin"}
+              </p>
+              {/* @ts-ignore */}
+              <p className="text-xs text-gray-500 truncate max-w-24 lg:max-w-none">{session?.user?.role}</p>
+            </div>
           </div>
         </div>
       </div>

--- a/components/admin/admin-sidebar.tsx
+++ b/components/admin/admin-sidebar.tsx
@@ -189,13 +189,13 @@ export default function AdminSidebar() {
           variant="ghost"
           size="icon"
           onClick={toggleSidebarCollapse}
-          className="absolute top-1/2 -right-3 lg:-right-4 transform -translate-y-1/2 bg-slate-800 hover:bg-slate-700 text-white rounded-full h-6 w-6 lg:h-8 lg:w-8 border-2 border-slate-900 shadow-lg"
+          className="absolute top-1/2 -right-3 lg:-right-4 transform -translate-y-1/2 bg-slate-800 hover:bg-slate-700 text-white rounded-full h-[20px] w-[20px] border-2 border-slate-900 shadow-lg"
           title={isSidebarCollapsed ? "Expandir sidebar" : "Recolher sidebar"}
         >
           {isSidebarCollapsed ? (
-            <ChevronsRight className="h-3 w-3 lg:h-4 lg:w-4" />
+            <ChevronsRight className="h-3 w-3" />
           ) : (
-            <ChevronsLeft className="h-3 w-3 lg:h-4 lg:w-4" />
+            <ChevronsLeft className="h-3 w-3" />
           )}
         </Button>
       </aside>


### PR DESCRIPTION
## Summary
- recreate the admin header with a simplified layout and smaller menu button

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68616b56d25083309d02a5fe09ad0b1d