### PR TITLE
Fix admin layout overflow with right aside

### DIFF
--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -63,17 +63,17 @@ function AdminLayoutContent({ children }: AdminLayoutProps) {
   }
 
   return (
-    <div className="flex h-screen bg-gray-50 overflow-hidden">
+    <div className="flex w-full h-screen overflow-hidden bg-gray-50">
       <AdminSidebar onCollapseChange={setSidebarCollapsed} />
-      <div className="flex flex-1 flex-col overflow-hidden min-w-0 overflow-x-hidden">
+      <main className="flex flex-col flex-1 overflow-hidden min-w-0">
         <AdminHeader />
-        <main className="flex-1 overflow-y-auto overflow-x-hidden max-w-[100vw]">
+        <div className="flex-1 overflow-y-auto overflow-x-hidden max-w-[100vw]">
           {children}
-        </main>
-      </div>
+        </div>
+      </main>
       <aside
         aria-hidden="true"
-        className={`hidden md:block transition-all duration-300 ${sidebarCollapsed ? "w-16 lg:w-20" : "w-56 lg:w-64"}`}
+        className="hidden md:block w-96 shrink-0 border-l"
       />
     </div>
   )

--- a/components/admin/admin-header.tsx
+++ b/components/admin/admin-header.tsx
@@ -10,8 +10,8 @@ export default function AdminHeader() {
   const { data: session } = useSession()
 
   return (
-    <header className="sticky top-0 z-50 w-full border-b bg-white">
-      <div className="flex items-center justify-between h-16 px-4 sm:px-6 lg:px-8 overflow-hidden max-w-full">
+    <header className="sticky top-0 z-50 border-b bg-white">
+      <div className="flex items-center justify-between h-16 px-4 sm:px-6 lg:px-8 overflow-hidden w-full">
         <div className="flex flex-1 items-center gap-2 sm:gap-4 min-w-0">
           <Sheet>
             <SheetTrigger asChild>


### PR DESCRIPTION
## Summary
- adjust `AdminHeader` width to inherit from main container
- restructure admin layout to allocate space for the new right panel

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6861762d9ed4833080d61324b6534348