### PR TITLE
Fix admin header layout

### DIFF
--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -65,16 +65,12 @@ function AdminLayoutContent({ children }: AdminLayoutProps) {
   return (
     <div className="flex w-full h-screen overflow-hidden bg-gray-50">
       <AdminSidebar onCollapseChange={setSidebarCollapsed} />
-      <main className="flex flex-col flex-1 overflow-hidden min-w-0">
+      <main className="flex flex-col flex-1 overflow-hidden overflow-x-hidden min-w-0">
         <AdminHeader />
-        <div className="flex-1 overflow-y-auto overflow-x-hidden max-w-[100vw]">
+        <div className="flex-1 overflow-y-auto overflow-x-hidden pt-16 max-w-[100vw]">
           {children}
         </div>
       </main>
-      <aside
-        aria-hidden="true"
-        className="hidden md:block w-96 shrink-0 border-l"
-      />
     </div>
   )
 }

--- a/components/admin/admin-header.tsx
+++ b/components/admin/admin-header.tsx
@@ -10,8 +10,8 @@ export default function AdminHeader() {
   const { data: session } = useSession()
 
   return (
-    <header className="sticky top-0 z-50 border-b bg-white">
-      <div className="flex items-center justify-between h-16 px-4 sm:px-6 lg:px-8 overflow-hidden w-full">
+    <header className="fixed top-0 left-0 z-50 w-full border-b bg-white">
+      <div className="relative flex items-center justify-between h-16 px-4 sm:px-6 lg:px-8 overflow-hidden w-full">
         <div className="flex flex-1 items-center gap-2 sm:gap-4 min-w-0">
           <Sheet>
             <SheetTrigger asChild>


### PR DESCRIPTION
## Summary
- remove unused right sidebar from admin layout
- fix admin header positioning
- ensure scroll container accounts for fixed header

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68617cac15bc8330af388265835868a6