### PR TITLE
Move user info to admin sidebar

### DIFF
--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -1,10 +1,9 @@
 "use client"
 
 import { SessionProvider, useSession } from "next-auth/react"
-import { type ReactNode, useEffect, useState } from "react"
+import { type ReactNode, useEffect } from "react"
 import { useRouter, usePathname } from "next/navigation"
 import AdminSidebar from "@/components/admin/admin-sidebar"
-import AdminHeader from "@/components/admin/admin-header"
 
 interface AdminLayoutProps {
   children: ReactNode
@@ -12,7 +11,6 @@ interface AdminLayoutProps {
 
 function AdminLayoutContent({ children }: AdminLayoutProps) {
   const { data: session, status } = useSession()
-  const [sidebarCollapsed, setSidebarCollapsed] = useState(false)
   const router = useRouter()
   const pathname = usePathname()
 
@@ -64,10 +62,9 @@ function AdminLayoutContent({ children }: AdminLayoutProps) {
 
   return (
     <div className="flex w-full h-screen overflow-hidden bg-gray-50">
-      <AdminSidebar onCollapseChange={setSidebarCollapsed} />
+      <AdminSidebar />
       <main className="flex flex-col flex-1 overflow-hidden overflow-x-hidden min-w-0">
-        <AdminHeader />
-        <div className="flex-1 overflow-y-auto overflow-x-hidden pt-16 max-w-[100vw]">
+        <div className="flex-1 overflow-y-auto overflow-x-hidden max-w-[100vw]">
           {children}
         </div>
       </main>

--- a/components/admin/admin-sidebar.tsx
+++ b/components/admin/admin-sidebar.tsx
@@ -13,8 +13,9 @@ import {
   X,
   ChevronsLeft,
   ChevronsRight,
+  UserCircle,
 } from "lucide-react"
-import { signOut } from "next-auth/react"
+import { signOut, useSession } from "next-auth/react"
 import { useState, useEffect } from "react"
 import { Button } from "@/components/ui/button"
 import Image from "next/image"
@@ -32,6 +33,7 @@ const navItems = [
 
 export default function AdminSidebar({ onCollapseChange }: AdminSidebarProps) {
   const pathname = usePathname()
+  const { data: session } = useSession()
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false)
   const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false)
 
@@ -125,7 +127,26 @@ export default function AdminSidebar({ onCollapseChange }: AdminSidebarProps) {
         })}
       </nav>
 
-      <div className={cn("p-2 sm:p-3 border-t border-slate-700 mt-auto", isSidebarCollapsed && "flex justify-center")}>
+      <div
+        className={cn(
+          "p-2 sm:p-3 border-t border-slate-700 mt-auto",
+          isSidebarCollapsed && "flex flex-col items-center"
+        )}
+      >
+        <div className="flex items-center gap-1 sm:gap-2 min-w-0 mb-2">
+          <UserCircle className="h-6 w-6 sm:h-7 sm:w-7 text-slate-400 flex-shrink-0" />
+          {!isSidebarCollapsed && (
+            <div className="hidden sm:block min-w-0">
+              <p className="text-xs sm:text-sm font-medium text-slate-200 truncate max-w-24 lg:max-w-none">
+                {session?.user?.name || "Admin"}
+              </p>
+              {/* @ts-ignore */}
+              <p className="text-xs text-slate-400 truncate max-w-24 lg:max-w-none">
+                {session?.user?.role}
+              </p>
+            </div>
+          )}
+        </div>
         <Button
           variant="ghost"
           onClick={() => signOut({ callbackUrl: "/admin/login" })}


### PR DESCRIPTION
## Summary
- drop AdminHeader from admin layout
- show current user info inside admin sidebar footer

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68618bccfd708330ba932895eb406dab