### PR TITLE
Add header to admin login

### DIFF
--- a/app/admin/login/loading.tsx
+++ b/app/admin/login/loading.tsx
@@ -1,6 +1,6 @@
 export default function LoginLoading() {
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-slate-50 to-slate-100">
+    <div className="h-dvh w-dvw flex items-center justify-center bg-gradient-to-br from-slate-50 to-slate-100 overflow-hidden">
       <div className="text-center">
         <div className="mx-auto flex h-20 w-20 items-center justify-center rounded-full bg-gradient-to-br from-slate-700 to-slate-800 text-white shadow-lg mb-4">
           <div className="h-8 w-8 animate-spin rounded-full border-2 border-white border-t-transparent"></div>

--- a/app/admin/login/page.tsx
+++ b/app/admin/login/page.tsx
@@ -8,6 +8,7 @@ import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
+import Header from "@/components/header"
 import { AlertTriangle, Eye, EyeOff } from "lucide-react"
 
 export default function AdminLoginPage() {
@@ -83,8 +84,10 @@ export default function AdminLoginPage() {
   }
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-slate-50 to-slate-100 px-4 py-12">
-      <Card className="w-full max-w-md shadow-2xl border-0">
+    <>
+      <Header />
+      <div className="h-dvh w-dvw flex items-center justify-center bg-gradient-to-br from-slate-50 to-slate-100 overflow-hidden">
+        <Card className="w-full max-w-md shadow-2xl border-0">
         <CardHeader className="text-center space-y-4">
           <div className="mx-auto flex h-20 w-20 items-center justify-center rounded-full bg-gradient-to-br from-slate-700 to-slate-800 text-white shadow-lg">
             <span className="text-2xl font-bold">GB</span>
@@ -182,6 +185,7 @@ export default function AdminLoginPage() {
           </div>
         </CardContent>
       </Card>
-    </div>
+      </div>
+    </>
   )
 }


### PR DESCRIPTION
## Summary
- show the site header on `/admin/login`
- make the login page and loader use `h-dvh` so the layout does not scroll

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68618d9b0d608330845e77f7ca0857df