### PR TITLE
Ajustes finais de responsividade na página de login admin

### DIFF
--- a/app/admin/login/page.tsx
+++ b/app/admin/login/page.tsx
@@ -86,8 +86,8 @@ export default function AdminLoginPage() {
   return (
     <>
       <Header />
-      <div className="h-dvh w-dvw flex items-center justify-center bg-gradient-to-br from-slate-50 to-slate-100 overflow-hidden">
-        <Card className="w-full max-w-md shadow-2xl border-0">
+      <div className="flex items-center justify-center min-h-screen sm:p-6 bg-gradient-to-br from-slate-50 to-slate-100">
+        <Card className="w-full max-w-md max-h-[calc(100vh-6rem)] overflow-y-auto shadow-2xl border-0">
         <CardHeader className="text-center space-y-4">
           <div className="mx-auto flex h-20 w-20 items-center justify-center rounded-full bg-gradient-to-br from-slate-700 to-slate-800 text-white shadow-lg">
             <span className="text-2xl font-bold">GB</span>
@@ -99,7 +99,7 @@ export default function AdminLoginPage() {
             </CardDescription>
           </div>
         </CardHeader>
-        <CardContent className="space-y-6">
+        <CardContent className="space-y-6 max-h-[calc(100vh-6rem)] overflow-y-auto">
           <form onSubmit={handleSubmit} className="space-y-6">
             {error && (
               <Alert variant="destructive" className="border-red-200 bg-red-50">

--- a/components/admin/admin-sidebar.tsx
+++ b/components/admin/admin-sidebar.tsx
@@ -133,7 +133,7 @@ export default function AdminSidebar({ onCollapseChange }: AdminSidebarProps) {
           isSidebarCollapsed && "flex flex-col items-center"
         )}
       >
-        <div className="flex items-center gap-1 sm:gap-2 min-w-0 mb-2">
+        <div className="flex items-center gap-1 sm:gap-2 min-w-0 mb-2 mx-auto">
           <UserCircle className="h-6 w-6 sm:h-7 sm:w-7 text-slate-400 flex-shrink-0" />
           {!isSidebarCollapsed && (
             <div className="hidden sm:block min-w-0">
@@ -195,7 +195,7 @@ export default function AdminSidebar({ onCollapseChange }: AdminSidebarProps) {
           variant="ghost"
           size="icon"
           onClick={toggleSidebarCollapse}
-          className="absolute top-1/2 -right-3 lg:-right-4 transform -translate-y-1/2 bg-slate-800 hover:bg-slate-700 text-white rounded-full h-[20px] w-[20px] border-2 border-slate-900 shadow-lg"
+          className="absolute top-1/2 -right-3 lg:-right-4 transform -translate-y-1/2 bg-slate-700 hover:bg-slate-600 text-white rounded-full h-6 w-6 border-2 border-slate-900 shadow-lg transition-colors hover:scale-105"
           title={isSidebarCollapsed ? "Expandir sidebar" : "Recolher sidebar"}
         >
           {isSidebarCollapsed ? (


### PR DESCRIPTION
## Summary
- centralizar conteúdo do login verticalmente com classe `min-h-screen sm:p-6`
- limitar altura do cartão de login e permitir scroll quando necessário

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861e82891948330bc8f70c01fd3ad9b