### PR TITLE
Fix Vercel build failure

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     "next": "15.2.4",
     "next-auth": "latest",
     "next-themes": "latest",
-    "node:crypto": "latest",
     "nodemailer": "6.9.0",
     "react": "^19",
     "react-day-picker": "latest",


### PR DESCRIPTION
## Summary
- remove `node:crypto` from dependencies

Removing this package resolves the outdated lockfile problem on Vercel.

## Testing
- `pnpm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6862adc61f5c8330a4cac8e3b579e6a8