### PR TITLE
Fix pnpm lock mismatch

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     "next": "15.2.4",
     "next-auth": "latest",
     "next-themes": "latest",
-    "node:crypto": "latest",
     "nodemailer": "6.9.0",
     "react": "^19",
     "react-day-picker": "latest",


### PR DESCRIPTION
## Summary
- remove invalid `node:crypto` dependency

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6862b1135b908330b4f31b3148753638