### PR TITLE
Fix admin quote APIs

### DIFF
--- a/app/api/admin/quotes/[id]/route.ts
+++ b/app/api/admin/quotes/[id]/route.ts
@@ -26,7 +26,9 @@ export async function GET(request: NextRequest, { params }: { params: { id: stri
                 category: {
                   select: {
                     name: true,
-                    color: true,
+                    iconColor: true,
+                    bgColor: true,
+                    fontColor: true,
                   },
                 },
               },

--- a/app/api/admin/quotes/route.ts
+++ b/app/api/admin/quotes/route.ts
@@ -23,7 +23,9 @@ export async function GET() {
                 category: {
                   select: {
                     name: true,
-                    color: true,
+                    iconColor: true,
+                    bgColor: true,
+                    fontColor: true,
                   },
                 },
               },


### PR DESCRIPTION
## Summary
- fix Prisma query to select iconColor, bgColor and fontColor for category in quotes API
- same update for single quote API endpoint

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: prompts to install vitest)*

------
https://chatgpt.com/codex/tasks/task_e_6863da0e23888330b162c9c7f091aa1b