### PR TITLE
Fix equipments filtering error

### DIFF
--- a/app/admin/equipamentos/page.tsx
+++ b/app/admin/equipamentos/page.tsx
@@ -58,7 +58,10 @@ export default function AdminEquipmentsPage() {
       const response = await fetch("/api/admin/equipments")
       if (response.ok) {
         const data = await response.json()
-        setEquipments(data)
+        // The API returns an object with an `equipments` array and pagination
+        // info. We only need the equipments list here.
+        const equipmentsData = Array.isArray(data) ? data : data.equipments
+        setEquipments(equipmentsData)
       } else {
         toast.error("Erro ao carregar equipamentos")
       }


### PR DESCRIPTION
## Summary
- parse `equipments` array from API response when fetching equipment list

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864020b2f608330b34bdeac30d4c29c