### PR TITLE
Fix quotes fetch

### DIFF
--- a/app/admin/dashboard/page.tsx
+++ b/app/admin/dashboard/page.tsx
@@ -95,7 +95,8 @@ export default function AdminDashboard() {
 
       if (quotesResponse.ok) {
         const quotesData = await quotesResponse.json()
-        setRecentQuotes(quotesData.slice(0, 5))
+        // The quotes endpoint returns an object with a `quotes` array
+        setRecentQuotes(quotesData.quotes.slice(0, 5))
       }
     } catch (error) {
       console.error("Erro ao carregar dados do dashboard:", error)

--- a/app/admin/orcamentos/page.tsx
+++ b/app/admin/orcamentos/page.tsx
@@ -109,7 +109,8 @@ export default function AdminQuotesPage() {
       const response = await fetch("/api/admin/quotes")
       if (response.ok) {
         const data = await response.json()
-        setQuotes(data)
+        // API returns an object with a `quotes` array
+        setQuotes(data.quotes)
       } else {
         toast.error("Erro ao carregar orçamentos")
       }


### PR DESCRIPTION
## Summary
- parse the admin quotes API response properly
- load recent quotes using the `quotes` array from API

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68640aec82ac83308273a12e9d960f28