### PR TITLE
Fix scroll animation cleanup

### DIFF
--- a/components/scroll-reveal-init.tsx
+++ b/components/scroll-reveal-init.tsx
@@ -260,7 +260,18 @@ export default function ScrollRevealInit() {
 
         allElements.forEach((element) => {
           const htmlElement = element as HTMLElement;
-          htmlElement.style.animation = "none";
+          htmlElement.style.removeProperty("animation");
+          htmlElement.style.removeProperty("opacity");
+          htmlElement.style.removeProperty("transform");
+          htmlElement.style.removeProperty("transition");
+        });
+
+        const contactCards = document.querySelectorAll(".contact-card");
+        contactCards.forEach((card) => {
+          const htmlCard = card as HTMLElement;
+          htmlCard.style.removeProperty("animation");
+          htmlCard.style.removeProperty("opacity");
+          htmlCard.style.removeProperty("transform");
         });
       }
     };


### PR DESCRIPTION
## Summary
- clear inline styles in `ScrollRevealInit` cleanup to avoid leftover DOM
  modifications between navigations and hydration mismatch

## Testing
- `pnpm lint`
- `pnpm test` *(fails: PASS waiting for file changes)*

------
https://chatgpt.com/codex/tasks/task_e_68655ff2df8883308950126d269ccfd7