### PR TITLE
Fix hydration mismatch warnings

### DIFF
--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -3,10 +3,12 @@ import * as React from "react";
 import { cn } from "@/lib/utils";
 
 const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
-  ({ className, type, ...props }, ref) => {
+  ({ className, type, spellCheck = false, ...props }, ref) => {
     return (
       <input
         type={type}
+        spellCheck={spellCheck}
+        suppressHydrationWarning
         className={cn(
           "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
           className,

--- a/components/ui/textarea.tsx
+++ b/components/ui/textarea.tsx
@@ -6,9 +6,11 @@ export interface TextareaProps
   extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
-  ({ className, ...props }, ref) => {
+  ({ className, spellCheck = false, ...props }, ref) => {
     return (
       <textarea
+        spellCheck={spellCheck}
+        suppressHydrationWarning
         className={cn(
           "flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
           className,


### PR DESCRIPTION
## Summary
- prevent hydration mismatch warnings by adding `spellCheck` defaults and the `suppressHydrationWarning` prop in reusable `Input` and `Textarea` components

## Testing
- `pnpm exec vitest run`

------
https://chatgpt.com/codex/tasks/task_e_686568df97cc8330bc12dd23e9d91aa8