### PR TITLE
Disable inline style linting

### DIFF
--- a/components/ui/modern-category-modal.tsx
+++ b/components/ui/modern-category-modal.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+/* eslint-disable no-inline-styles */
+
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import {


### PR DESCRIPTION
## Summary
- disable the `no-inline-styles` rule for ModernCategoryModal with an ESLint comment

## Testing
- `pnpm lint` *(fails: Definition for rule 'no-inline-styles' was not found)*
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_686d1a3c2e98833091022be214876c3f