### PR TITLE
Fix fetchQuotes initialization

### DIFF
--- a/app/admin/orcamentos/page.tsx
+++ b/app/admin/orcamentos/page.tsx
@@ -93,14 +93,6 @@ export default function AdminQuotesPage() {
   const [isUpdating, setIsUpdating] = useState(false);
   const { toast } = useToast();
 
-  useEffect(() => {
-    fetchQuotes();
-  }, [fetchQuotes]);
-
-  useEffect(() => {
-    filterQuotes();
-  }, [quotes, searchTerm, statusFilter, filterQuotes]);
-
   const fetchQuotes = useCallback(async () => {
     try {
       setLoading(true);
@@ -144,6 +136,14 @@ export default function AdminQuotesPage() {
 
     setFilteredQuotes(filtered);
   }, [quotes, searchTerm, statusFilter]);
+
+  useEffect(() => {
+    fetchQuotes();
+  }, [fetchQuotes]);
+
+  useEffect(() => {
+    filterQuotes();
+  }, [quotes, searchTerm, statusFilter, filterQuotes]);
 
   const updateQuoteStatus = async (quoteId: string, newStatus: 'approved' | 'rejected') => {
     try {


### PR DESCRIPTION
## Summary
- define `fetchQuotes` and `filterQuotes` before their effects to avoid runtime ReferenceError

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_686d61e316b4833093acc5228e946c5f