### PR TITLE
Fix popover scrolling issue

### DIFF
--- a/components/ui/modern-category-modal.tsx
+++ b/components/ui/modern-category-modal.tsx
@@ -525,7 +525,7 @@ export function ModernCategoryModal({
                     </Button>
                   </PopoverTrigger>
                   <PopoverContent
-                    className="w-[380px] max-w-[calc(100vw-3rem)] p-0 shadow-2xl border rounded-lg bg-white z-[99999] fixed left-[50%] top-[50%] translate-x-[-50%] translate-y-[-50%]"
+                    className="w-[380px] max-w-[calc(100vw-3rem)] max-h-[70vh] overflow-y-auto p-0 shadow-2xl border rounded-lg bg-white z-[99999] fixed left-[50%] top-[50%] translate-x-[-50%] translate-y-[-50%]"
                     align="center"
                     side="bottom"
                     sideOffset={8}


### PR DESCRIPTION
## Objetivo

Corrige o popover de edição da categoria para que o conteúdo seja rolável quando exceder a altura da tela.

## Como testar

1. Rodar `pnpm install` caso ainda não tenha dependências.
2. Executar `pnpm lint` e `pnpm test`.
3. Abrir o modal de edição de categoria e verificar que o popover possui scroll ao ultrapassar 70vh.

## Checklist

- [x] Código limpo
- [x] Testes passando
- [x] Sem alteração de design

------
https://chatgpt.com/codex/tasks/task_e_686d75c1f72c8330be36a4e879f383b3