### PR TITLE
Fix popover scroll in category modal

### DIFF
--- a/components/ui/modern-category-modal.tsx
+++ b/components/ui/modern-category-modal.tsx
@@ -525,7 +525,7 @@ export function ModernCategoryModal({
                     </Button>
                   </PopoverTrigger>
                   <PopoverContent
-                    className="w-[380px] max-w-[calc(100vw-3rem)] p-0 shadow-2xl border rounded-lg bg-white z-[99999] fixed left-[50%] top-[50%] translate-x-[-50%] translate-y-[-50%]"
+                    className="modal-centered-popover w-[380px] max-w-[calc(100vw-3rem)] p-0 shadow-2xl border rounded-lg bg-white"
                     align="center"
                     side="bottom"
                     sideOffset={8}


### PR DESCRIPTION
## Objetivo

Garante que o popover de edição na modal de categoria utilize a classe de estilo correta para habilitar rolagem.

## Como testar

1. Rodar `pnpm install` caso necessário.
2. Executar `pnpm lint` e `pnpm test`.
3. Abrir o popover de edição de categoria e verificar que ele respeita `max-height` de 70vh e possui scroll.

## Checklist

- [x] Código limpo
- [x] Testes passando
- [x] Sem alteração de design

------
https://chatgpt.com/codex/tasks/task_e_686d75c1f72c8330be36a4e879f383b3