### PR TITLE
Fix popover scrolling inside modal

### DIFF
--- a/components/ui/modern-category-modal.tsx
+++ b/components/ui/modern-category-modal.tsx
@@ -495,7 +495,7 @@ export function ModernCategoryModal({
 
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent className="w-full max-w-lg max-h-[90vh] p-0 gap-0 bg-white border-0 shadow-2xl rounded-lg overflow-hidden data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed !left-[50%] !top-[50%] z-50 grid !translate-x-[-50%] !translate-y-[-50%] !m-0">
+      <DialogContent className="w-full max-w-lg max-h-[90vh] p-0 gap-0 bg-white border-0 shadow-2xl rounded-lg overflow-visible data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed !left-[50%] !top-[50%] z-50 grid !translate-x-[-50%] !translate-y-[-50%] !m-0">
         {/* Header */}
         <DialogHeader className="p-6 border-b border-gray-100 bg-gradient-to-r from-slate-50 to-slate-100 rounded-t-lg">
           <DialogTitle className="text-xl font-semibold text-gray-800 flex items-center gap-3">
@@ -532,6 +532,7 @@ export function ModernCategoryModal({
                     avoidCollisions={false}
                     collisionPadding={0}
                     sticky="always"
+                    portal={false}
                     onOpenAutoFocus={(e) => e.preventDefault()}
                     onCloseAutoFocus={(e) => e.preventDefault()}
                   >


### PR DESCRIPTION
## Objetivo

Corrigir o scroll do componente `<PopoverContent />` no modal de categorias modernas.

## Como testar

1. Rode `pnpm install` para garantir dependências.
2. Execute `pnpm dev` e abra o modal de categorias.
3. Clique em **Editar** para abrir o popover e verificar que o conteúdo rola normalmente.

## Checklist

- [x] Código limpo
- [x] Testes passando
- [x] Sem alteração de design

------
https://chatgpt.com/codex/tasks/task_e_686ee56f24a8833089267e019388cdac