### PR TITLE
Fix popover scroll inside modal

### DIFF
--- a/components/ui/modern-category-modal.tsx
+++ b/components/ui/modern-category-modal.tsx
@@ -532,7 +532,6 @@ export function ModernCategoryModal({
                     avoidCollisions={false}
                     collisionPadding={0}
                     sticky="always"
-                    portal={false}
                     onOpenAutoFocus={(e) => e.preventDefault()}
                     onCloseAutoFocus={(e) => e.preventDefault()}
                   >


### PR DESCRIPTION
## Objetivo

Resolver a impossibilidade de rolar o conteúdo do popover dentro da modal de categoria.

## Como testar

1. Abrir a modal de categorias.
2. Clicar em "Editar" para abrir o popover.
3. Verificar que é possível rolar o conteúdo normalmente.

## Checklist

- [x] Código limpo
- [ ] Testes passando
- [ ] Sem alteração de design

------
https://chatgpt.com/codex/tasks/task_e_686fcb88f0ec83308420e2e80ae0a976