### PR TITLE
Fix popover scroll inside modal

### DIFF
--- a/components/ui/modern-category-modal.tsx
+++ b/components/ui/modern-category-modal.tsx
@@ -513,7 +513,7 @@ export function ModernCategoryModal({
             <div className="bg-gradient-to-br from-slate-50 to-slate-100 rounded-lg p-5 border border-slate-200 shadow-sm relative">
               <div className="flex items-center justify-between mb-4">
                 <h3 className="text-sm font-semibold text-slate-700">Preview da Categoria</h3>
-                <Popover open={isDesignOpen} onOpenChange={setIsDesignOpen}>
+                <Popover modal open={isDesignOpen} onOpenChange={setIsDesignOpen}>
                   <PopoverTrigger asChild>
                     <Button
                       variant="outline"

--- a/components/ui/popover.tsx
+++ b/components/ui/popover.tsx
@@ -13,18 +13,16 @@ const PopoverContent = React.forwardRef<
   React.ElementRef<typeof PopoverPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
 >(({ className, align = 'center', sideOffset = 4, ...props }, ref) => (
-  <PopoverPrimitive.Portal>
-    <PopoverPrimitive.Content
-      ref={ref}
-      align={align}
-      sideOffset={sideOffset}
-      className={cn(
-        'z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
-        className,
-      )}
-      {...props}
-    />
-  </PopoverPrimitive.Portal>
+  <PopoverPrimitive.Content
+    ref={ref}
+    align={align}
+    sideOffset={sideOffset}
+    className={cn(
+      'z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+      className,
+    )}
+    {...props}
+  />
 ));
 PopoverContent.displayName = PopoverPrimitive.Content.displayName;
 


### PR DESCRIPTION
## Objetivo

Corrige o popover de edição dentro do modal de categorias, permitindo rolagem com o mouse.

## Como testar

1. Rode `pnpm install` (caso ainda não tenha).
2. Execute `pnpm lint` e `pnpm test` – ambos devem passar.
3. Abra a modal de categorias e o popover de edição; o conteúdo deve rolar normalmente.

## Checklist
- [x] Código limpo
- [x] Testes passando
- [x] Sem alteração de design

------
https://chatgpt.com/codex/tasks/task_e_686fe457d99483308ab01805076666de