### PR TITLE
Fix CloseButton usage in category modal

### DIFF
--- a/components/ui/modern-category-modal.tsx
+++ b/components/ui/modern-category-modal.tsx
@@ -2,6 +2,7 @@
 
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { CloseButton } from '@/components/ui/close-button';
 import {
   Dialog,
   DialogContent,
@@ -563,19 +564,12 @@ export function ModernCategoryModal({
                           >
                             Remove
                           </Button>
-                          <Button
-                            variant="ghost"
-                            size="sm"
+                          <CloseButton
                             onClick={() => setIsDesignOpen(false)}
-                            className="text-slate-400 hover:text-slate-600 h-7 px-2 rounded-lg"
-                            style={{
-                              display: 'inline-flex',
-                              alignItems: 'center',
-                              justifyContent: 'center',
-                            }}
-                          >
-                            <X className="w-3.5 h-3.5" />
-                          </Button>
+                            className="text-slate-400 hover:text-slate-600 h-7 w-7"
+                            size="sm"
+                            variant="ghost"
+                          />
                         </div>
                       </div>
 


### PR DESCRIPTION
## Objetivo

Use the universal `CloseButton` component for the popover close action inside `modern-category-modal.tsx`. This keeps the same hover and styling behavior as the dialog close button.

## Como testar

1. `pnpm install`
2. `pnpm lint`
3. `pnpm test`

The modal's popover close button should now share the same hover styles as the dialog close button.

## Checklist

- [x] Código limpo
- [x] Testes passando
- [x] Sem alteração de design

------
https://chatgpt.com/codex/tasks/task_e_686ffc377340833082c83b0576230396