### PR TITLE
Fix CloseButton ref forwarding

### DIFF
--- a/components/ui/close-button.tsx
+++ b/components/ui/close-button.tsx
@@ -1,14 +1,12 @@
+'use client';
+
 import React from 'react';
 import { X } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
-interface CloseButtonProps {
-  onClick?: () => void;
-  className?: string;
+interface CloseButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   size?: 'sm' | 'md' | 'lg';
   variant?: 'default' | 'ghost' | 'outline';
-  disabled?: boolean;
-  'aria-label'?: string;
 }
 
 const sizeClasses = {
@@ -31,41 +29,31 @@ const iconSizes = {
   lg: 'h-5 w-5',
 };
 
-export const CloseButton: React.FC<CloseButtonProps> = ({
-  onClick,
-  className,
-  size = 'md',
-  variant = 'default',
-  disabled = false,
-  'aria-label': ariaLabel = 'Close',
-}) => {
-  return (
+export const CloseButton = React.forwardRef<HTMLButtonElement, CloseButtonProps>(
+  (
+    { className, size = 'md', variant = 'default', 'aria-label': ariaLabel = 'Close', ...props },
+    ref,
+  ) => (
     <button
       type="button"
-      onClick={onClick}
-      disabled={disabled}
+      ref={ref}
       aria-label={ariaLabel}
       className={cn(
-        // Base styles
         'inline-flex items-center justify-center rounded-lg transition-all',
         'focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
         'disabled:pointer-events-none disabled:opacity-50',
-
-        // Size classes
         sizeClasses[size],
-
-        // Variant classes
         variantClasses[variant],
-
-        // Custom className
         className,
       )}
+      {...props}
     >
       <X className={iconSizes[size]} />
       <span className="sr-only">{ariaLabel}</span>
     </button>
-  );
-};
+  ),
+);
+CloseButton.displayName = 'CloseButton';
 
 // Export para facilitar o uso
 export default CloseButton;

--- a/components/ui/modern-category-modal.tsx
+++ b/components/ui/modern-category-modal.tsx
@@ -2,6 +2,7 @@
 
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { CloseButton } from '@/components/ui/close-button';
 import {
   Dialog,
   DialogContent,
@@ -563,19 +564,12 @@ export function ModernCategoryModal({
                           >
                             Remove
                           </Button>
-                          <Button
-                            variant="ghost"
-                            size="sm"
+                          <CloseButton
                             onClick={() => setIsDesignOpen(false)}
-                            className="text-slate-400 hover:text-slate-600 h-7 px-2 rounded-lg"
-                            style={{
-                              display: 'inline-flex',
-                              alignItems: 'center',
-                              justifyContent: 'center',
-                            }}
-                          >
-                            <X className="w-3.5 h-3.5" />
-                          </Button>
+                            className="text-slate-400 hover:text-slate-600 h-7 w-7"
+                            size="sm"
+                            variant="ghost"
+                          />
                         </div>
                       </div>
 


### PR DESCRIPTION
## Objetivo

Ensure the universal close button works correctly inside Radix `Dialog`. The component now forwards its ref and all props so hover styles apply consistently.

## Como testar

1. `pnpm install`
2. `pnpm lint`
3. `pnpm test`

The modal close button should now match the popover close button.

## Checklist
- [x] Código limpo
- [x] Testes passando
- [x] Sem alteração de design

------
https://chatgpt.com/codex/tasks/task_e_686ffc377340833082c83b0576230396