### PR TITLE
Remove default focus outline

### DIFF
--- a/app/admin/categorias/page.tsx
+++ b/app/admin/categorias/page.tsx
@@ -294,7 +294,7 @@ export default function AdminCategoriesPage() {
                     placeholder="Buscar categorias..."
                     value={searchTerm}
                     onChange={(e) => setSearchTerm(e.target.value)}
-                    className="pl-10 border-gray-200 focus:border-blue-500 focus:ring-blue-500"
+                    className="pl-10 border-gray-200 focus:border-blue-500 focus-visible:ring-blue-500"
                   />
                 </div>
                 <Button

--- a/app/admin/login/page.clean.tsx
+++ b/app/admin/login/page.clean.tsx
@@ -103,7 +103,7 @@ export default function AdminLoginPage() {
                   onChange={(e) => setEmail(e.target.value)}
                   required
                   disabled={isLoading}
-                  className="h-11 border-slate-300 focus:border-orange-500 focus:ring-orange-500/20"
+                  className="h-11 border-slate-300 focus:border-orange-500 focus-visible:ring-orange-500/20"
                 />
               </div>
 
@@ -120,7 +120,7 @@ export default function AdminLoginPage() {
                     onChange={(e) => setPassword(e.target.value)}
                     required
                     disabled={isLoading}
-                    className="h-11 pr-10 border-slate-300 focus:border-orange-500 focus:ring-orange-500/20"
+                    className="h-11 pr-10 border-slate-300 focus:border-orange-500 focus-visible:ring-orange-500/20"
                   />
                   <Button
                     type="button"

--- a/app/admin/login/page.tsx
+++ b/app/admin/login/page.tsx
@@ -186,7 +186,7 @@ export default function AdminLoginPage() {
                       value={email}
                       onChange={(e) => setEmail(e.target.value)}
                       disabled={isLoading}
-                      className="h-12 border-slate-300 focus:border-slate-500 focus:ring-slate-500 text-sm placeholder:text-slate-400 bg-white/90 backdrop-blur-sm transition-all duration-200 rounded-2xl shadow-sm hover:shadow-md focus:shadow-lg"
+                      className="h-12 border-slate-300 focus:border-slate-500 focus-visible:ring-slate-500 text-sm placeholder:text-slate-400 bg-white/90 backdrop-blur-sm transition-all duration-200 rounded-2xl shadow-sm hover:shadow-md focus:shadow-lg"
                       aria-label="Digite seu e-mail de administrador"
                     />
                   </div>
@@ -207,7 +207,7 @@ export default function AdminLoginPage() {
                         value={password}
                         onChange={(e) => setPassword(e.target.value)}
                         disabled={isLoading}
-                        className="h-12 border-slate-300 focus:border-slate-500 focus:ring-slate-500 pr-12 text-sm placeholder:text-slate-400 bg-white/90 backdrop-blur-sm transition-all duration-200 rounded-2xl shadow-sm hover:shadow-md focus:shadow-lg"
+                        className="h-12 border-slate-300 focus:border-slate-500 focus-visible:ring-slate-500 pr-12 text-sm placeholder:text-slate-400 bg-white/90 backdrop-blur-sm transition-all duration-200 rounded-2xl shadow-sm hover:shadow-md focus:shadow-lg"
                         aria-label="Digite sua senha de administrador"
                       />
                       <Button
@@ -231,7 +231,7 @@ export default function AdminLoginPage() {
                   <div className="pt-1">
                     <Button
                       type="submit"
-                      className="w-full h-12 bg-gradient-to-r from-slate-700 to-slate-800 hover:from-slate-800 hover:to-slate-900 text-white font-semibold text-sm shadow-xl hover:shadow-2xl transition-all duration-300 focus:ring-2 focus:ring-slate-400 focus:ring-offset-2 transform hover:scale-[1.02] disabled:transform-none rounded-2xl"
+                      className="w-full h-12 bg-gradient-to-r from-slate-700 to-slate-800 hover:from-slate-800 hover:to-slate-900 text-white font-semibold text-sm shadow-xl hover:shadow-2xl transition-all duration-300 focus-visible:ring-2 focus-visible:ring-slate-400 focus-visible:ring-offset-2 transform hover:scale-[1.02] disabled:transform-none rounded-2xl"
                       disabled={isLoading}
                       aria-label="Entrar no Painel Administrativo"
                     >

--- a/app/admin/orcamentos/page.tsx
+++ b/app/admin/orcamentos/page.tsx
@@ -265,13 +265,13 @@ export default function AdminQuotesPage() {
                     placeholder="Buscar por nome, email, empresa..."
                     value={searchTerm}
                     onChange={(e) => setSearchTerm(e.target.value)}
-                    className="pl-10 border-gray-200 focus:border-blue-500 focus:ring-blue-500"
+                    className="pl-10 border-gray-200 focus:border-blue-500 focus-visible:ring-blue-500"
                   />
                 </div>
                 <div className="flex items-center gap-2">
                   <Filter className="w-4 h-4 text-gray-500" />
                   <Select value={statusFilter} onValueChange={setStatusFilter}>
-                    <SelectTrigger className="w-48 border-gray-200 focus:border-blue-500 focus:ring-blue-500">
+                    <SelectTrigger className="w-48 border-gray-200 focus:border-blue-500 focus-visible:ring-blue-500">
                       <SelectValue placeholder="Filtrar por status" />
                     </SelectTrigger>
                     <SelectContent>

--- a/components/categories-with-animation.tsx
+++ b/components/categories-with-animation.tsx
@@ -140,7 +140,7 @@ export default function CategoriesWithAnimation() {
                   ref={(el) => {
                     cardsRef.current[index] = el;
                   }}
-                  className="h-full transition-all duration-500 hover:shadow-2xl hover:-translate-y-2 group-focus:ring-2 group-focus:ring-orange-500 overflow-hidden relative"
+                  className="h-full transition-all duration-500 hover:shadow-2xl hover:-translate-y-2 group-focus-visible:ring-2 group-focus-visible:ring-orange-500 overflow-hidden relative"
                   style={{
                     opacity: 0,
                     transform: 'translateY(60px)',

--- a/components/ui/badge.tsx
+++ b/components/ui/badge.tsx
@@ -4,7 +4,7 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@/lib/utils';
 
 const badgeVariants = cva(
-  'inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
+  'inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
   {
     variants: {
       variant: {

--- a/components/ui/close-button.tsx
+++ b/components/ui/close-button.tsx
@@ -42,7 +42,7 @@ export const CloseButton = React.forwardRef<HTMLButtonElement, CloseButtonProps>
       aria-label={ariaLabel}
       className={cn(
         'inline-flex items-center justify-center rounded-lg transition-all',
-        'focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
+        'focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
         'disabled:pointer-events-none disabled:opacity-50',
         sizeClasses[size],
         variantClasses[variant],

--- a/components/ui/modern-category-modal.tsx
+++ b/components/ui/modern-category-modal.tsx
@@ -673,7 +673,7 @@ export function ModernCategoryModal({
                   <Badge
                     variant="outline"
                     className={cn(
-                      'category-preview-badge text-xs focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 inline-flex items-center gap-2 font-medium px-4 py-2 rounded-xl border-0 max-w-full transition-all duration-300',
+                      'category-preview-badge text-xs focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 inline-flex items-center gap-2 font-medium px-4 py-2 rounded-xl border-0 max-w-full transition-all duration-300',
                       'shadow-[4px_8px_18px_2px_rgba(0,0,0,0.18)] hover:shadow-[8px_12px_20px_2px_rgba(0,0,0,0.22)]',
                       'hover:scale-[1.07]',
                     )}
@@ -709,8 +709,9 @@ export function ModernCategoryModal({
                   onChange={(e) => setFormData({ ...formData, name: e.target.value })}
                   placeholder="Ex: Ferramentas de Construção"
                   className={cn(
-                    'h-11 text-sm bg-slate-50 border-slate-200 focus:bg-white transition-colors rounded-lg focus:ring-2 focus:ring-slate-500/20',
-                    errors.name && 'border-red-500 focus:border-red-500 focus:ring-red-500/20',
+                    'h-11 text-sm bg-slate-50 border-slate-200 focus:bg-white transition-colors rounded-lg focus-visible:ring-2 focus-visible:ring-slate-500/20',
+                    errors.name &&
+                      'border-red-500 focus:border-red-500 focus-visible:ring-red-500/20',
                   )}
                 />
                 {errors.name && (
@@ -733,9 +734,9 @@ export function ModernCategoryModal({
                   placeholder="Descreva brevemente esta categoria..."
                   rows={3}
                   className={cn(
-                    'text-sm bg-slate-50 border-slate-200 focus:bg-white transition-colors resize-none rounded-lg focus:ring-2 focus:ring-slate-500/20',
+                    'text-sm bg-slate-50 border-slate-200 focus:bg-white transition-colors resize-none rounded-lg focus-visible:ring-2 focus-visible:ring-slate-500/20',
                     errors.description &&
-                      'border-red-500 focus:border-red-500 focus:ring-red-500/20',
+                      'border-red-500 focus:border-red-500 focus-visible:ring-red-500/20',
                   )}
                 />
                 {errors.description && (

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -19,7 +19,7 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      'flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1',
+      'flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1',
       className,
     )}
     {...props}

--- a/components/ui/toast.tsx
+++ b/components/ui/toast.tsx
@@ -61,7 +61,7 @@ const ToastAction = React.forwardRef<
   <ToastPrimitives.Action
     ref={ref}
     className={cn(
-      'inline-flex h-8 shrink-0 items-center justify-center rounded-md border bg-transparent px-3 text-sm font-medium ring-offset-background transition-colors hover:bg-secondary focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 group-[.destructive]:border-muted/40 group-[.destructive]:hover:border-destructive/30 group-[.destructive]:hover:bg-destructive group-[.destructive]:hover:text-destructive-foreground group-[.destructive]:focus:ring-destructive',
+      'inline-flex h-8 shrink-0 items-center justify-center rounded-md border bg-transparent px-3 text-sm font-medium ring-offset-background transition-colors hover:bg-secondary focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 group-[.destructive]:border-muted/40 group-[.destructive]:hover:border-destructive/30 group-[.destructive]:hover:bg-destructive group-[.destructive]:hover:text-destructive-foreground group-[.destructive]:focus-visible:ring-destructive',
       className,
     )}
     {...props}


### PR DESCRIPTION
## Objetivo

Remover o contorno preto nativo de foco e padronizar o uso de `focus-visible` em elementos interativos.

## Como testar

1. Rodar `pnpm lint` e `pnpm test` (podem falhar por dependências ausentes).
2. Navegar pela aplicação e verificar que botões, inputs, selects e links exibem o anel de foco do TailwindCSS sem outline preto.

## Checklist

- [x] Código limpo
- [ ] Testes passando
- [x] Sem alteração de design


------
https://chatgpt.com/codex/tasks/task_e_6870987501008330980a7abc180421d5