### PR TITLE
fix: modal safe area support

### DIFF
--- a/components/ui/modern-category-modal.tsx
+++ b/components/ui/modern-category-modal.tsx
@@ -494,6 +494,8 @@ export function ModernCategoryModal({
           style={{
             paddingTop: 'env(safe-area-inset-top)',
             paddingBottom: 'env(safe-area-inset-bottom)',
+            height: 'calc(100svh - env(safe-area-inset-top) - env(safe-area-inset-bottom))',
+            maxHeight: 'calc(100svh - env(safe-area-inset-top) - env(safe-area-inset-bottom))',
           }}
         >
           <DialogHeader className="p-6 border-b border-gray-100 bg-gradient-to-r from-slate-50 to-slate-100 rounded-t-lg flex-shrink-0">


### PR DESCRIPTION
## Objetivo

Garantir que o modal de categorias ajuste sua altura considerando as safe areas de dispositivos móveis, evitando cortes em telas com notch ou barras de navegação.

## Como testar

1. Rodar `pnpm lint` e `pnpm test`.
2. Abrir o modal de categorias em um dispositivo móvel ou emulador e verificar que o conteúdo não ultrapassa a área visível.

## Checklist

- [x] Código limpo
- [x] Testes passando
- [x] Sem alteração de design
- [x] Nenhum uso de outline

------
https://chatgpt.com/codex/tasks/task_e_687821659f488330ac45bb7704eed1cc