### PR TITLE
Fix iOS safe areas for category modal

### DIFF
--- a/app/ClientLayout.tsx
+++ b/app/ClientLayout.tsx
@@ -31,7 +31,7 @@ export default function ClientLayout({ children }: { children: React.ReactNode }
         <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
         <link rel="shortcut icon" href="/favicon.svg" type="image/svg+xml" />
         <meta name="theme-color" content="#334155" />
-        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
       </head>
       <body className={`${inter.className} antialiased overflow-x-hidden`}>
         {!isAdminRoute && <Header />}

--- a/components/ui/modern-category-modal.tsx
+++ b/components/ui/modern-category-modal.tsx
@@ -490,12 +490,12 @@ export function ModernCategoryModal({
       <Dialog open={isOpen} onOpenChange={onClose}>
         <DialogContent
           closeButtonClassName="hover:bg-white"
-          className="w-full max-w-lg h-[100svh] max-h-[100svh] p-0 gap-0 bg-white border-0 shadow-2xl rounded-lg overflow-visible data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed !left-[50%] !top-[50%] z-50 flex flex-col !translate-x-[-50%] !translate-y-[-50%] !m-0 xs:max-w-[98vw] xs:p-0"
+          className="fixed left-1/2 -translate-x-1/2 z-50 flex flex-col w-full max-w-lg p-0 gap-0 bg-white border-0 shadow-2xl rounded-lg overflow-visible data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 m-0 xs:max-w-[98vw] xs:p-0"
           style={{
+            top: 'env(safe-area-inset-top)',
+            bottom: 'env(safe-area-inset-bottom)',
             paddingTop: 'env(safe-area-inset-top)',
             paddingBottom: 'env(safe-area-inset-bottom)',
-            height: 'calc(100svh - env(safe-area-inset-top) - env(safe-area-inset-bottom))',
-            maxHeight: 'calc(100svh - env(safe-area-inset-top) - env(safe-area-inset-bottom))',
           }}
         >
           <DialogHeader className="p-6 border-b border-gray-100 bg-gradient-to-r from-slate-50 to-slate-100 rounded-t-lg flex-shrink-0">
@@ -506,7 +506,7 @@ export function ModernCategoryModal({
               {title}
             </DialogTitle>
           </DialogHeader>
-          <ScrollArea className="flex-1 min-h-0 max-h-full w-full overflow-y-auto">
+          <ScrollArea className="flex-1 overflow-y-auto">
             <div className="p-6 space-y-6 xs:p-1 xs:space-y-3 w-full max-w-full">
               {/* Preview da Categoria */}
               <div className="bg-gradient-to-br from-slate-50 to-slate-100 rounded-lg p-5 border border-slate-200 shadow-sm relative w-full max-w-full xs:p-2 xs:rounded-md">


### PR DESCRIPTION
## Objetivo

Ajusta o `<DialogContent>` da modal de categorias para respeitar as safe areas do Safari em iOS, mantendo a centralização horizontal.

## Como testar

1. Rodar `pnpm lint` e `pnpm test`.
2. Abrir a aplicação em um iPhone/simulador e verificar que a modal de categorias não fica sob o notch ou a barra de endereços.

## Checklist

- [x] Código limpo
- [x] Testes passando
- [x] Sem alteração de design
- [x] Nenhum uso de outline

------
https://chatgpt.com/codex/tasks/task_e_68790c092bd083308c36a07d3821c09e