### PR TITLE
Fix popover height on small screens

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -681,7 +681,7 @@ div[class*='text-xs'][class*='inline-flex'][class*='items-center'][class*='gap-2
 
 /* Garantir centralização perfeita de modais */
 
-[role='dialog'] {
+[role='dialog']:not([data-radix-popover-content]) {
   position: fixed !important;
   left: 50% !important;
   top: 50% !important;
@@ -697,7 +697,7 @@ div[class*='text-xs'][class*='inline-flex'][class*='items-center'][class*='gap-2
 
 /* Responsividade para telas pequenas */
 @media (max-width: 640px) {
-  [role='dialog'] {
+  [role='dialog']:not([data-radix-popover-content]) {
     max-width: 95vw !important;
     height: 100% !important;
     max-height: 95vh !important;


### PR DESCRIPTION
## Objetivo

Ajustar a regra de CSS que afetava popovers ao definir 100% de altura para elementos com `role="dialog"` em telas menores.

## Como testar

- Executar `pnpm lint` e `pnpm test`.
- Abrir a aplicação e verificar que o popover mantém seu tamanho correto em dispositivos móveis enquanto a modal principal continua ocupando 100% da altura.

## Checklist

- [x] Código limpo
- [x] Testes passando
- [x] Sem alteração de design
- [x] Nenhum uso de outline

------
https://chatgpt.com/codex/tasks/task_e_687928bcbc408330be8b5f00efe3d90d