### PR TITLE
Fix popover height on small screens

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -681,7 +681,7 @@ div[class*='text-xs'][class*='inline-flex'][class*='items-center'][class*='gap-2
 
 /* Garantir centralização perfeita de modais */
 
-[role='dialog'] {
+[role='dialog'][data-dialog-content] {
   position: fixed !important;
   left: 50% !important;
   top: 50% !important;
@@ -697,7 +697,7 @@ div[class*='text-xs'][class*='inline-flex'][class*='items-center'][class*='gap-2
 
 /* Responsividade para telas pequenas */
 @media (max-width: 640px) {
-  [role='dialog'] {
+  [role='dialog'][data-dialog-content] {
     max-width: 95vw !important;
     height: 100% !important;
     max-height: 95vh !important;

--- a/components/ui/alert-dialog.tsx
+++ b/components/ui/alert-dialog.tsx
@@ -34,6 +34,7 @@ const AlertDialogContent = React.forwardRef<
   <AlertDialogPortal>
     <AlertDialogOverlay />
     <AlertDialogPrimitive.Content
+      data-dialog-content
       ref={ref}
       className={cn(
         'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -44,6 +44,7 @@ const DialogContent = React.forwardRef<
     <DialogPortal>
       <DialogOverlay />
       <DialogPrimitive.Content
+        data-dialog-content
         ref={ref}
         className={cn(
           'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg sm:rounded-lg',


### PR DESCRIPTION
## Objetivo

Restringir o CSS de altura 100% apenas para modais, evitando que popovers sejam afetados.

## Como testar

- Executar `pnpm lint` e `pnpm test`.
- Abrir a aplicação e verificar que popovers exibem o conteúdo completo em dispositivos móveis, enquanto modais continuam usando toda a altura.

## Checklist

- [x] Código limpo
- [x] Testes passando
- [x] Sem alteração de design
- [x] Nenhum uso de outline

------
https://chatgpt.com/codex/tasks/task_e_687928bcbc408330be8b5f00efe3d90d