### PR TITLE
Fix popover position in modal

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -697,7 +697,7 @@ div[class*='text-xs'][class*='inline-flex'][class*='items-center'][class*='gap-2
 
 /* Responsividade para telas pequenas */
 @media (max-width: 640px) {
-  [role='dialog'] {
+  [role='dialog']:not([data-radix-popover-content]) {
     max-width: 95vw !important;
     height: 100% !important;
     max-height: 95vh !important;


### PR DESCRIPTION
## Objetivo

Garantir que popovers continuem centralizados dentro da modal sem aplicar a regra de 100% de altura.

## Como testar

- Rodar `pnpm lint` e `pnpm test`.
- Abrir uma modal que contém popover e verificar que o popover aparece centralizado e com altura correta.

## Checklist

- [x] Código limpo
- [x] Testes passando
- [x] Sem alteração de design
- [x] Nenhum uso de outline

------
https://chatgpt.com/codex/tasks/task_e_687928bcbc408330be8b5f00efe3d90d