### PR TITLE
Fix popover collapse

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -681,7 +681,7 @@ div[class*='text-xs'][class*='inline-flex'][class*='items-center'][class*='gap-2
 
 /* Garantir centralização perfeita de modais */
 
-[role='dialog'] {
+[role='dialog']:not(.popover-content) {
   position: fixed !important;
   left: 50% !important;
   top: 50% !important;
@@ -697,7 +697,7 @@ div[class*='text-xs'][class*='inline-flex'][class*='items-center'][class*='gap-2
 
 /* Responsividade para telas pequenas */
 @media (max-width: 640px) {
-  [role='dialog'] {
+  [role='dialog']:not([data-radix-popover-content]):not(.popover-content) {
     max-width: 95vw !important;
     height: 100% !important;
     max-height: 95vh !important;
@@ -808,12 +808,14 @@ div[class*='text-xs'][class*='inline-flex'][class*='items-center'][class*='gap-2
 }
 
 /* Garantir scroll funcionando em popovers */
-[data-radix-popover-content] {
-  max-height: 70vh;
+[data-radix-popover-content],
+.popover-content {
+  max-height: 90vh;
   overflow-y: auto !important;
   pointer-events: auto !important;
   touch-action: pan-y !important;
   overscroll-behavior: contain !important;
+  display: block !important; /* Override flex layout from generic dialog rule */
 }
 
 /* =============================== */

--- a/components/ui/modern-category-modal.tsx
+++ b/components/ui/modern-category-modal.tsx
@@ -524,7 +524,8 @@ export function ModernCategoryModal({
                       </Button>
                     </PopoverTrigger>
                     <PopoverContent
-                      className="w-[380px] max-w-[calc(100vw-3rem)] p-0 shadow-2xl border rounded-lg bg-white z-[99999] max-h-[70vh] overflow-y-auto left-[50%] top-[50%] translate-x-[-50%] translate-y-[-50%]"
+                      className="popover-content fixed left-1/2 top-1/2 w-[512px] max-w-[calc(100vw-3rem)] p-0 shadow-2xl border rounded-lg bg-white z-[99999] overflow-y-auto -translate-x-1/2 -translate-y-1/2"
+                      style={{ maxHeight: '90vh' }}
                       align="center"
                       side="bottom"
                       sideOffset={8}


### PR DESCRIPTION
## Objetivo

Restaurar a largura do popover para evitar que ele fique colapsado.

## Como testar

- `pnpm lint`
- `pnpm test`
- Abrir a modal de categoria e verificar que o popover é exibido com largura adequada.

## Checklist
- [x] Código limpo
- [x] Testes passando
- [x] Sem alteração de design
- [x] Nenhum uso de outline

------
https://chatgpt.com/codex/tasks/task_e_687928bcbc408330be8b5f00efe3d90d