### PR TITLE
Fix popover content clipping

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -814,8 +814,10 @@ div[class*='text-xs'][class*='inline-flex'][class*='items-center'][class*='gap-2
 /* Garantir scroll funcionando em popovers */
 [data-radix-popover-content],
 .popover-content {
-  max-height: 90vh;
-  overflow-y: auto !important;
+  /* Permitir que o popover cresça conforme o conteúdo interno */
+  max-height: none !important;
+  height: auto !important;
+  overflow: visible !important;
   pointer-events: auto !important;
   touch-action: pan-y !important;
   overscroll-behavior: contain !important;

--- a/components/ui/modern-category-modal.tsx
+++ b/components/ui/modern-category-modal.tsx
@@ -524,8 +524,7 @@ export function ModernCategoryModal({
                       </Button>
                     </PopoverTrigger>
                     <PopoverContent
-                      className="popover-content fixed left-1/2 top-1/2 w-[512px] max-w-[calc(100vw-3rem)] p-0 shadow-2xl border rounded-lg bg-white z-[99999] overflow-y-auto -translate-x-1/2 -translate-y-1/2"
-                      style={{ maxHeight: '90vh' }}
+                      className="popover-content fixed left-1/2 top-1/2 w-[512px] max-w-[calc(100vw-3rem)] p-0 shadow-2xl border rounded-lg bg-white z-[99999] -translate-x-1/2 -translate-y-1/2"
                       align="center"
                       side="bottom"
                       sideOffset={8}

--- a/components/ui/popover.tsx
+++ b/components/ui/popover.tsx
@@ -19,6 +19,7 @@ const PopoverContent = React.forwardRef<
     sideOffset={sideOffset}
     className={cn(
       'z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+      '!max-h-none !h-auto !overflow-visible',
       className,
     )}
     {...props}


### PR DESCRIPTION
## Objetivo

Evita que o conteúdo dos popovers seja cortado adicionando estilos que permitem crescimento total do elemento.

## Como testar

1. Executar `pnpm lint` e `pnpm test`.
2. Abrir qualquer popover e verificar que todo o conteúdo aparece sem barra de rolagem interna.

## Checklist

- [x] Código limpo
- [x] Testes passando
- [x] Sem alteração de design
- [x] Nenhum uso de outline

------
https://chatgpt.com/codex/tasks/task_e_687a1ec784108330bb042bcaf091a7b8