### PR TITLE
Implement portal-based popover

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -818,6 +818,9 @@ div[class*='text-xs'][class*='inline-flex'][class*='items-center'][class*='gap-2
   max-height: none !important;
   height: auto !important;
   overflow: visible !important;
+  /* em mobile Safari: limitar pelo viewport descontando safe areas */
+  /* para casos extremos, usar overflow-y:auto e definir max-height */
+  /* max-height: calc(100vh - env(safe-area-inset-top) - env(safe-area-inset-bottom)) !important; */
   pointer-events: auto !important;
   touch-action: pan-y !important;
   overscroll-behavior: contain !important;

--- a/components/ui/popover.tsx
+++ b/components/ui/popover.tsx
@@ -12,19 +12,26 @@ const PopoverTrigger = PopoverPrimitive.Trigger;
 const PopoverContent = React.forwardRef<
   React.ElementRef<typeof PopoverPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
->(({ className, align = 'center', sideOffset = 4, ...props }, ref) => (
-  <PopoverPrimitive.Content
-    ref={ref}
-    align={align}
-    sideOffset={sideOffset}
-    className={cn(
-      'z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
-      '!max-h-none !h-auto !overflow-visible',
-      className,
-    )}
-    {...props}
-  />
-));
+>(
+  // Usamos Portal para evitar containers limitantes
+  // !max-h-none e !h-auto garantem que o popover sempre mostre TODO o conteúdo
+  // safe-area-inset* assegura compatibilidade com barras do iOS
+  ({ className, align = 'center', sideOffset = 4, ...props }, ref) => (
+    <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Content
+        ref={ref}
+        align={align}
+        sideOffset={sideOffset}
+        className={cn(
+          'z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+          '!max-h-none !h-auto !overflow-visible sm:!max-h-[calc(100vh-env(safe-area-inset-top)-env(safe-area-inset-bottom))] sm:overflow-auto',
+          className,
+        )}
+        {...props}
+      />
+    </PopoverPrimitive.Portal>
+  ),
+);
 PopoverContent.displayName = PopoverPrimitive.Content.displayName;
 
 export { Popover, PopoverTrigger, PopoverContent };


### PR DESCRIPTION
## Objetivo

Ajustar o componente de popover para que todo o conteúdo seja exibido em dispositivos iOS, evitando cortes e respeitando as safe areas.

## Como testar

1. Rode `pnpm install` caso ainda não tenha as dependências.
2. Execute `pnpm lint` e `pnpm test` para garantir que tudo continua funcionando.
3. Acesse uma tela que utilize `PopoverContent` e verifique que o popover abre por completo, inclusive em navegadores mobile.

## Checklist

- [x] Código limpo
- [x] Testes passando
- [x] Sem alteração de design
- [x] Nenhum uso de outline

------
https://chatgpt.com/codex/tasks/task_e_687a24c5107c83308a30fd20708be0ac