### PR TITLE
Fix categories scroll reveal

### DIFF
--- a/components/categories.tsx
+++ b/components/categories.tsx
@@ -2,7 +2,7 @@
 
 import { Card, CardContent } from '@/components/ui/card';
 import * as LucideIcons from 'lucide-react';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useRef } from 'react';
 
 interface ApiCategory {
   id: string;
@@ -79,6 +79,8 @@ const fallbackCategories: Category[] = [
 ];
 
 export default function Categories() {
+  const sectionRef = useRef<HTMLElement | null>(null);
+  const cardsRef = useRef<(HTMLDivElement | null)[]>([]);
   const [categories, setCategories] = useState<Category[]>(fallbackCategories);
 
   useEffect(() => {
@@ -111,14 +113,43 @@ export default function Categories() {
     fetchCategories();
   }, []);
 
+  useEffect(() => {
+    const section = sectionRef.current;
+    if (!section) return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            section
+              .querySelectorAll<HTMLElement>(
+                '.animate-on-scroll, .animate-on-scroll-delayed, .category-card-animate',
+              )
+              .forEach((el, idx) => {
+                if (el.classList.contains('category-card-animate')) {
+                  setTimeout(() => el.classList.add('animate-in'), idx * 150);
+                } else {
+                  el.classList.add('animate-in');
+                }
+              });
+            observer.unobserve(entry.target);
+          }
+        });
+      },
+      { threshold: 0.2 },
+    );
+
+    observer.observe(section);
+    return () => observer.disconnect();
+  }, [categories]);
+
   return (
-    <section className="py-16 bg-gray-50">
+    <section ref={sectionRef} className="py-16 bg-gray-50">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="text-center mb-12">
-          <h2 className="section-title text-3xl md:text-4xl font-bold text-gray-900 mb-4 opacity-0">
+          <h2 className="section-title text-3xl md:text-4xl font-bold text-gray-900 mb-4 animate-on-scroll">
             Categorias de Equipamentos
           </h2>
-          <p className="section-subtitle text-xl text-gray-600 max-w-2xl mx-auto opacity-0">
+          <p className="section-subtitle text-xl text-gray-600 max-w-2xl mx-auto animate-on-scroll-delayed">
             Encontre rapidamente o equipamento especializado que você precisa para sua obra
           </p>
         </div>
@@ -129,7 +160,10 @@ export default function Categories() {
             return (
               <Card
                 key={index}
-                className="benefit-card bg-white/90 backdrop-blur-sm border-gray-200 hover:bg-white transition-all duration-500 hover:scale-105 hover:shadow-2xl group overflow-hidden relative opacity-0"
+                ref={(el) => {
+                  cardsRef.current[index] = el;
+                }}
+                className="benefit-card category-card category-card-animate bg-white/90 backdrop-blur-sm border-gray-200 hover:bg-white transition-all duration-500 hover:scale-105 hover:shadow-2xl group overflow-hidden relative"
               >
                 <div
                   className={`absolute inset-0 bg-gradient-to-br ${category.color} opacity-0 group-hover:opacity-10 transition-opacity duration-500`}

--- a/components/home-page-client.tsx
+++ b/components/home-page-client.tsx
@@ -1,16 +1,7 @@
 'use client';
 
-import dynamic from 'next/dynamic';
-
-const Categories = dynamic(() => import('./categories'), {
-  ssr: false,
-  loading: () => <div className="h-96 bg-gray-100 animate-pulse" />,
-});
-
-const FeaturedMaterials = dynamic(() => import('./featured-materials'), {
-  ssr: false,
-  loading: () => <div className="h-96 bg-gray-100 animate-pulse" />,
-});
+import Categories from './categories';
+import FeaturedMaterials from './featured-materials';
 
 export default function HomePageClient() {
   return (

--- a/components/scroll-reveal-init.tsx
+++ b/components/scroll-reveal-init.tsx
@@ -36,17 +36,12 @@ export default function ScrollRevealInit() {
 
       // Verificar se é navegação interna (clique em link do próprio site)
       const isInternalNavigation = () => {
-        const navigationType = getNavigationType();
         const wasInternalClick = sessionStorage.getItem('internalNavigation') === 'true';
 
         // Limpar flag de navegação interna
         sessionStorage.removeItem('internalNavigation');
 
-        // Se foi um clique interno OU se o tipo é 'navigate' e temos histórico de estar no site
-        return (
-          wasInternalClick ||
-          (navigationType === 'navigate' && sessionStorage.getItem('hasVisitedSite') === 'true')
-        );
+        return wasInternalClick;
       };
 
       // Detectar se é dispositivo móvel
@@ -60,16 +55,31 @@ export default function ScrollRevealInit() {
       const shouldExecuteAnimations = !isInternalNavigation();
       const isOnMobile = isMobile();
 
+      const selectors =
+        '.hero-title, .hero-subtitle, .hero-search, .hero-buttons, .hero-contact, .hero-image, ' +
+        '.section-title, .section-subtitle, .category-card, .material-card, .benefit-card, ' +
+        '.contact-form, .contact-info, .cta-section, .animate-on-scroll, .animate-on-scroll-delayed, .category-card-animate';
+
+      const initializeElement = (element: HTMLElement) => {
+        if (
+          element.classList.contains('animate-on-scroll') ||
+          element.classList.contains('animate-on-scroll-delayed') ||
+          element.classList.contains('category-card-animate')
+        ) {
+          element.classList.remove('animate-in');
+        } else {
+          element.style.opacity = '0';
+          element.style.transform = 'translateY(60px)';
+          element.style.transition = 'none';
+        }
+      };
+
       // Marcar que o usuário já visitou o site
       sessionStorage.setItem('hasVisitedSite', 'true');
 
       // Função para mostrar todos os elementos imediatamente (sem animação)
       const showAllElementsImmediately = () => {
-        const animatedElements = document.querySelectorAll(
-          '.hero-title, .hero-subtitle, .hero-search, .hero-buttons, .hero-contact, .hero-image, ' +
-            '.section-title, .section-subtitle, .category-card, .material-card, .benefit-card, ' +
-            '.contact-form, .contact-info, .cta-section, .animate-on-scroll, .animate-on-scroll-delayed, .category-card-animate',
-        );
+        const animatedElements = document.querySelectorAll(selectors);
 
         animatedElements.forEach((element) => {
           const htmlElement = element as HTMLElement;
@@ -102,17 +112,10 @@ export default function ScrollRevealInit() {
 
       // Função para inicializar elementos como invisíveis (para animação)
       const initializeElementsForAnimation = () => {
-        const animatedElements = document.querySelectorAll(
-          '.hero-title, .hero-subtitle, .hero-search, .hero-buttons, .hero-contact, .hero-image, ' +
-            '.section-title, .section-subtitle, .category-card, .material-card, .benefit-card, ' +
-            '.contact-form, .contact-info, .cta-section',
-        );
+        const animatedElements = document.querySelectorAll(selectors);
 
         animatedElements.forEach((element) => {
-          const htmlElement = element as HTMLElement;
-          htmlElement.style.opacity = '0';
-          htmlElement.style.transform = 'translateY(60px)';
-          htmlElement.style.transition = 'none';
+          initializeElement(element as HTMLElement);
         });
       };
 
@@ -220,24 +223,42 @@ export default function ScrollRevealInit() {
       };
 
       // Lógica principal
+      let observer: IntersectionObserver | null = null;
+      let mutation: MutationObserver | null = null;
+
       if (shouldExecuteAnimations) {
         // EXECUTAR ANIMAÇÕES: Refresh, URL digitada, nova aba, etc.
         // Aguardar a hidratação antes de manipular o DOM
+
         setTimeout(() => {
           initializeElementsForAnimation();
 
           requestAnimationFrame(() => {
-            const observer = setupObserver();
+            observer = setupObserver();
+            mutation = new MutationObserver((records) => {
+              records.forEach((record) => {
+                record.addedNodes.forEach((node) => {
+                  if (node.nodeType === 1) {
+                    const el = node as HTMLElement;
+                    if (el.matches(selectors)) {
+                      initializeElement(el);
+                      observer?.observe(el);
+                    }
+                    el.querySelectorAll(selectors).forEach((child) => {
+                      initializeElement(child as HTMLElement);
+                      observer?.observe(child as HTMLElement);
+                    });
+                  }
+                });
+              });
+            });
+            mutation.observe(document.body, { childList: true, subtree: true });
 
             // Delay menor para mobile para animações mais rápidas
             const observerDelay = isOnMobile ? 50 : 100;
 
             setTimeout(() => {
-              const elementsToObserve = document.querySelectorAll(
-                '.hero-title, .hero-subtitle, .hero-search, .hero-buttons, .hero-contact, .hero-image, ' +
-                  '.section-title, .section-subtitle, .category-card, .material-card, .benefit-card, ' +
-                  '.contact-form, .contact-info, .cta-section, .animate-on-scroll, .animate-on-scroll-delayed, .category-card-animate',
-              );
+              const elementsToObserve = document.querySelectorAll(selectors);
 
               elementsToObserve.forEach((element) => {
                 observer.observe(element);
@@ -255,12 +276,10 @@ export default function ScrollRevealInit() {
       // Cleanup function
       return () => {
         if (shouldExecuteAnimations) {
-          const allElements = document.querySelectorAll(
-            '.hero-title, .hero-subtitle, .hero-search, .hero-buttons, .hero-contact, .hero-image, ' +
-              '.section-title, .section-subtitle, .category-card, .material-card, .benefit-card, ' +
-              '.contact-form, .contact-info, .cta-section, .animate-on-scroll, .animate-on-scroll-delayed, .category-card-animate',
-          );
+          observer?.disconnect();
+          mutation?.disconnect();
 
+          const allElements = document.querySelectorAll(selectors);
           allElements.forEach((element) => {
             const htmlElement = element as HTMLElement;
             htmlElement.style.animation = 'none';


### PR DESCRIPTION
## Objetivo

Corrigir erro de variável duplicada e garantir que a seção de categorias só seja exibida ao entrar na viewport.

## Como testar

1. `pnpm install`
2. `pnpm lint`
3. `pnpm test`
4. Rode `pnpm dev` e acesse a home; role até a sessão de categorias e verifique que os itens aparecem sem flicker.

## Checklist

- [x] Código limpo
- [x] Testes passando
- [x] Sem alteração de design
- [x] Nenhum uso de outline

------
https://chatgpt.com/codex/tasks/task_e_687fe7d7b3b0833092bb8c70da2cf3eb