### PR TITLE
fix: restore categories animation

### DIFF
--- a/components/categories.tsx
+++ b/components/categories.tsx
@@ -135,7 +135,7 @@ export default function Categories() {
           }
         });
       },
-      { threshold: 0.2 },
+      { threshold: 0.1, rootMargin: '0px 0px -50px 0px' },
     );
 
     observer.observe(section);


### PR DESCRIPTION
## Objetivo

Corrigir o desaparecimento da animação da seção **Categorias**.

## Como testar

1. `pnpm install`
2. `pnpm lint`
3. `pnpm test`
4. Rodar o projeto com `pnpm dev` e acessar a home. A animação deve iniciar somente quando a seção de categorias entrar na tela.

## Checklist
- [x] Código limpo
- [x] Testes passando
- [x] Sem alteração de design
- [x] Nenhum uso de outline

------
https://chatgpt.com/codex/tasks/task_e_68803401f0e8833080336c739490c510