### PR TITLE
fix: restore scroll animation for categories

### DIFF
--- a/components/categories.tsx
+++ b/components/categories.tsx
@@ -2,7 +2,7 @@
 
 import { Card, CardContent } from '@/components/ui/card';
 import * as LucideIcons from 'lucide-react';
-import React, { useEffect, useState, useRef } from 'react';
+import React, { useEffect, useState } from 'react';
 
 interface ApiCategory {
   id: string;
@@ -79,8 +79,6 @@ const fallbackCategories: Category[] = [
 ];
 
 export default function Categories() {
-  const sectionRef = useRef<HTMLElement | null>(null);
-  const cardsRef = useRef<(HTMLDivElement | null)[]>([]);
   const [categories, setCategories] = useState<Category[]>(fallbackCategories);
 
   useEffect(() => {
@@ -113,37 +111,8 @@ export default function Categories() {
     fetchCategories();
   }, []);
 
-  useEffect(() => {
-    const section = sectionRef.current;
-    if (!section) return;
-    const observer = new IntersectionObserver(
-      (entries) => {
-        entries.forEach((entry) => {
-          if (entry.isIntersecting) {
-            section
-              .querySelectorAll<HTMLElement>(
-                '.animate-on-scroll, .animate-on-scroll-delayed, .category-card-animate',
-              )
-              .forEach((el, idx) => {
-                if (el.classList.contains('category-card-animate')) {
-                  setTimeout(() => el.classList.add('animate-in'), idx * 150);
-                } else {
-                  el.classList.add('animate-in');
-                }
-              });
-            observer.unobserve(entry.target);
-          }
-        });
-      },
-      { threshold: 0.1, rootMargin: '0px 0px -50px 0px' },
-    );
-
-    observer.observe(section);
-    return () => observer.disconnect();
-  }, [categories]);
-
   return (
-    <section ref={sectionRef} className="py-16 bg-gray-50">
+    <section className="py-16 bg-gray-50">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="text-center mb-12">
           <h2 className="section-title text-3xl md:text-4xl font-bold text-gray-900 mb-4 animate-on-scroll">
@@ -160,9 +129,6 @@ export default function Categories() {
             return (
               <Card
                 key={index}
-                ref={(el) => {
-                  cardsRef.current[index] = el;
-                }}
                 className="benefit-card category-card category-card-animate bg-white/90 backdrop-blur-sm border-gray-200 hover:bg-white transition-all duration-500 hover:scale-105 hover:shadow-2xl group overflow-hidden relative"
               >
                 <div


### PR DESCRIPTION
## Objetivo

Restaurar a animação de scroll da seção "Categorias de Equipamentos".

## Como testar

1. Instale dependências com `pnpm install`.
2. Execute `pnpm lint` e `pnpm test` para validar.
3. Rode o projeto com `pnpm dev` e acesse a home page.
4. Ao rolar até a seção de categorias, os cards devem animar normalmente.

## Checklist

- [x] Código limpo
- [x] Testes passando
- [x] Sem alteração de design
- [x] Nenhum uso de outline

------
https://chatgpt.com/codex/tasks/task_e_688036154058833098404e96cbe51355