### PR TITLE
Atualiza lint e Vercel

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,7 @@
 module.exports = {
-  extends: ['next/core-web-vitals', 'prettier'],
+  root: true,
+  extends: ['next/core-web-vitals', 'eslint:recommended'],
+  rules: {
+    // suas regras customizadas aqui
+  },
 };

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "preinstall": "npx only-allow pnpm",
-    "lint": "eslint . --ext .js,.ts,.tsx --no-color --quiet || exit 0",
+    "lint": "eslint --ext .js,.jsx,.ts,.tsx .",
     "lint:fix": "next lint --fix",
     "start": "next start",
     "test": "vitest",

--- a/vercel.json
+++ b/vercel.json
@@ -3,10 +3,7 @@
   "build": {
     "env": {},
     "installCommand": "pnpm install",
-    "buildCommand": "pnpm run build"
-  },
-  "eslint": {
-    "ignoreDuringBuilds": true
+    "buildCommand": "npm run lint && npm run build"
   },
   "typescript": {
     "ignoreBuildErrors": true


### PR DESCRIPTION
## Objetivo

Remoção da configuração de eslint do `vercel.json` e criação do `.eslintrc.js` padronizado. Script de lint ajustado e build da Vercel passa a rodar o lint antes do build.

## Como testar

1. `pnpm lint`
2. `pnpm exec vitest run`

## Checklist

- [x] Código limpo
- [x] Testes passando
- [x] Sem alteração de design
- [x] Nenhum uso de outline

------
https://chatgpt.com/codex/tasks/task_e_6883d06377f88330829cdfc44e15cfbe