### PR TITLE
fix vercel config

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -5,9 +5,6 @@
     "installCommand": "pnpm install",
     "buildCommand": "npm run lint && npm run build"
   },
-  "typescript": {
-    "ignoreBuildErrors": true
-  },
   "images": {
     "formats": ["image/avif", "image/webp"],
     "sizes": [16, 32, 48, 64, 96, 128, 256, 512]


### PR DESCRIPTION
## Objetivo

Remove invalid `typescript` key from `vercel.json` that caused schema validation errors on Vercel.

## Como testar

1. Execute `pnpm lint`.
2. Execute `pnpm exec vitest run`.
3. Deploy the project; the build should proceed without the previous error.

## Checklist

- [x] Código limpo
- [x] Testes passando
- [x] Sem alteração de design
- [x] Nenhum uso de outline

------
https://chatgpt.com/codex/tasks/task_e_6883d42f2b948330883dbf8247e95d1f