### PR TITLE
fix vercel config

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,11 +2,7 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "build": {
     "env": {},
-    "installCommand": "pnpm install",
     "buildCommand": "npm run lint && npm run build"
-  },
-  "typescript": {
-    "ignoreBuildErrors": true
   },
   "images": {
     "formats": ["image/avif", "image/webp"],


### PR DESCRIPTION
## Objetivo

Remove chave `installCommand` inválida do `vercel.json` que causava erro de validação no deploy.

## Como testar

1. Execute `pnpm lint`.
2. Execute `pnpm exec vitest run`.
3. Realize o deploy e verifique que o erro de schema não ocorre mais.

## Checklist

- [x] Código limpo
- [x] Testes passando
- [x] Sem alteração de design
- [x] Nenhum uso de outline

------
https://chatgpt.com/codex/tasks/task_e_6883d42f2b948330883dbf8247e95d1f