### PR TITLE
fix: update vercel config

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,9 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "build": {
-    "env": {},
-    "buildCommand": "npm run lint && npm run build"
-  },
+  "buildCommand": "npm run lint && npm run build",
   "images": {
     "formats": ["image/avif", "image/webp"],
     "sizes": [16, 32, 48, 64, 96, 128, 256, 512]


### PR DESCRIPTION
## Objetivo

Ajustar o `vercel.json` para atender ao schema do Vercel, movendo `buildCommand` para a raiz do arquivo.

## Como testar

1. Executar `pnpm lint`.
2. Executar `pnpm exec vitest run`.
3. Verificar que o build na Vercel não acusa erro de schema.

## Checklist

- [x] Código limpo
- [x] Testes passando
- [x] Sem alteração de design
- [x] Nenhum uso de outline

------
https://chatgpt.com/codex/tasks/task_e_6883d78e76ac83309e1125bae5c03d4f