### PR TITLE
chore: configurar workspace pnpm para build no Vercel

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,5 +129,10 @@
   "engines": {
     "node": ">=18.0.0",
     "pnpm": ">=8.0.0"
+  },
+  "workspaces": {
+    "packages": [
+      "."
+    ]
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,10 +1,2 @@
 packages:
   - '.'
-
-onlyBuiltDependencies:
-  - '@prisma/client'
-  - '@prisma/engines'
-  - '@vercel/speed-insights'
-  - esbuild
-  - prisma
-  - sharp


### PR DESCRIPTION
## Objetivo

Configura o projeto para utilizar o workspace do pnpm exigido pelo Vercel.

## Como testar

1. Execute `pnpm install`.
2. Rode `pnpm lint` e `pnpm exec vitest run`.

## Checklist

- [x] Código limpo
- [x] Testes passando
- [x] Sem alteração de design
- [x] Nenhum uso de outline

------
https://chatgpt.com/codex/tasks/task_e_6883daddc9c883308b765d3ae047b2cf