### PR TITLE
Fix Prisma usage in admin equipments page

### DIFF
--- a/app/admin/equipamentos/page.tsx
+++ b/app/admin/equipamentos/page.tsx
@@ -1,4 +1,3 @@
-'use client';
 // ...existing code...
 
 import { prisma } from '@/lib/prisma';


### PR DESCRIPTION
## Objetivo

Corrige erro de execução do Prisma no navegador removendo o `use client` da página de listagem de equipamentos.

## Como testar

1. Rode `pnpm install`.
2. Execute `pnpm lint` e `pnpm test -- --run` para verificar.
3. Inicie o projeto com `pnpm dev` e acesse `/admin/equipamentos`.

## Checklist

- [x] Código limpo
- [x] Testes passando
- [x] Sem alteração de design
- [x] Nenhum uso de outline

------
https://chatgpt.com/codex/tasks/task_e_6883f6a4bd688330b03599aaabef7e1f