### PR TITLE
Fix dynamic server warnings

### DIFF
--- a/app/api/admin/dashboard/route.ts
+++ b/app/api/admin/dashboard/route.ts
@@ -1,4 +1,6 @@
 import { type NextRequest, NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';

--- a/app/api/admin/quotes/[id]/route.ts
+++ b/app/api/admin/quotes/[id]/route.ts
@@ -3,6 +3,8 @@ import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 
+export const dynamic = 'force-dynamic';
+
 export async function GET(request: NextRequest, { params }: { params: { id: string } }) {
   try {
     const session = await getServerSession(authOptions);

--- a/app/api/admin/quotes/route.ts
+++ b/app/api/admin/quotes/route.ts
@@ -4,6 +4,8 @@ import { Prisma, QuoteStatus } from '@prisma/client';
 import { getServerSession } from 'next-auth';
 import { type NextRequest, NextResponse } from 'next/server';
 
+export const dynamic = 'force-dynamic';
+
 export async function GET(request: NextRequest) {
   try {
     const session = await getServerSession(authOptions);


### PR DESCRIPTION
## Objetivo

Resolve mensagens de `Dynamic server usage` na Vercel informando que rotas admin utilizavam `headers`.

## Como testar

1. Executar `pnpm lint` e `pnpm exec vitest run`.
2. Verificar que não há erros de build e os testes passam.

## Checklist
- [x] Código limpo
- [x] Testes passando
- [x] Sem alteração de design
- [x] Nenhum uso de outline

------
https://chatgpt.com/codex/tasks/task_e_68840dbc5f0483309ef1d57ed3dbadaf