### PR TITLE
Apply focus styles and cleanup

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -117,9 +117,7 @@
   ::file-selector-button {
     border-color: hsl(var(--border, 214.3 31.8% 91.4%));
   }
-}
 
-@layer base {
   button:not(:disabled),
   [role='button']:not(:disabled),
   [type='button']:not(:disabled),
@@ -131,19 +129,11 @@
   textarea::placeholder {
     color: hsl(var(--muted-foreground));
   }
-}
 
-@layer base {
-  button:not(:disabled),
-  [role='button']:not(:disabled),
-  [type='button']:not(:disabled),
-  [type='submit']:not(:disabled) {
-    cursor: pointer;
-  }
-
-  input::placeholder,
-  textarea::placeholder {
-    color: hsl(var(--muted-foreground));
+  input:not([type='checkbox']):not([type='radio']),
+  select,
+  textarea {
+    @apply border-gray-200 focus:border-blue-500 focus:outline-blue-500 focus:outline-2 focus:ring-0;
   }
 }
 
@@ -1033,9 +1023,3 @@ div[class*='text-xs'][class*='inline-flex'][class*='items-center'][class*='gap-2
 
 /* Forçar scroll funcional dentro do Popover (ShadCN UI) */
 /* (Reutiliza as mesmas regras definidas acima) */
-
-*:focus,
-*:focus-visible,
-*:focus-within {
-  outline: none !important;
-}

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -5,7 +5,7 @@ import * as React from 'react';
 import { cn } from '@/lib/utils';
 
 const buttonVariants = cva(
-  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all duration-300 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
+  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all duration-300 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 focus:outline-blue-500 focus:outline-2 focus:ring-0',
   {
     variants: {
       variant: {

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -9,7 +9,7 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<'input'>>(
         suppressHydrationWarning
         type={type}
         className={cn(
-          'flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+          'flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50 md:text-sm focus:border-blue-500 focus:outline-blue-500 focus:outline-2 focus:ring-0',
           className,
         )}
         ref={ref}

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -19,7 +19,7 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      'flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1',
+      'flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1 focus:border-blue-500 focus:outline-blue-500 focus:outline-2 focus:ring-0',
       className,
     )}
     {...props}

--- a/components/ui/textarea.tsx
+++ b/components/ui/textarea.tsx
@@ -10,7 +10,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
       <textarea
         suppressHydrationWarning
         className={cn(
-          'flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50',
+          'flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50 focus:border-blue-500 focus:outline-blue-500 focus:outline-2 focus:ring-0',
           className,
         )}
         ref={ref}


### PR DESCRIPTION
## Objetivo

Ajusta estilos globais e componentes para manter consistência de foco conforme TailwindCSS v4.

## Como testar

1. `pnpm install`
2. `pnpm lint`
3. `pnpm test -- --run`

## Checklist
- [x] Código limpo
- [x] Testes passando
- [x] Sem alteração de design
- [x] Foco azul (`focus:border-blue-500` ou `focus:outline-blue-500`)


------
https://chatgpt.com/codex/tasks/task_e_688807f46ab88330a3810c801e6a110f