### PR TITLE
Fix Radix dropdown positioning

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -710,13 +710,7 @@ div[class*='text-xs'][class*='inline-flex'][class*='items-center'][class*='gap-2
 /* 12. Modal, Popover, e Layouts   */
 /* =============================== */
 /* Modal e Popover - Centralização perfeita */
-[data-radix-popper-content-wrapper] {
-  position: fixed !important;
-  left: 50% !important;
-  top: 50% !important;
-  transform: translate(-50%, -50%) !important;
-  z-index: 99999 !important;
-}
+/* Centralização de modais e popovers será controlada pelos próprios componentes */
 
 /* Garantir centralização perfeita de modais */
 


### PR DESCRIPTION
## Objetivo

Remover regra global que centralizava todo conteúdo com `data-radix-popper-content-wrapper`, o que fazia os dropdowns do Radix aparecerem sempre no centro da tela.

## Como testar

1. `pnpm install`
2. `pnpm lint`
3. `pnpm test --run`
4. Abrir `/admin/equipamentos` e verificar que cada Select abre abaixo do seu trigger.

## Checklist
- [x] Código limpo
- [x] Testes passando
- [x] Sem alteração de design
- [x] Foco azul (`focus:border-blue-500` ou `focus:outline-blue-500`)


------
https://chatgpt.com/codex/tasks/task_e_688a3b2083b08330958a2a83b09ebf56