### PR TITLE
fix: ensure filter dropdowns stack above content

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -41,6 +41,10 @@
     --sidebar-accent-foreground: 240 5.9% 10%;
     --sidebar-border: 220 13% 91%;
     --sidebar-ring: 217.2 91.2% 59.8%;
+    --z-dropdown: 9999;
+    --z-modal: 10000;
+    --z-popover: 10001;
+    --z-tooltip: 10002;
   }
   .dark {
     --background: 222.2 84% 4.9%;
@@ -239,12 +243,12 @@ textarea[class*='bg-background']:focus {
 /* 2.1. Correções Radix UI Select  */
 /* =============================== */
 [data-radix-popper-content-wrapper] {
-  z-index: 9999 !important;
+  z-index: var(--z-popover) !important;
 }
 
 [data-radix-select-content] {
   position: absolute !important;
-  z-index: 9999 !important;
+  z-index: var(--z-dropdown) !important;
 }
 
 /* Garantir que o Portal do Radix funcione corretamente */
@@ -252,7 +256,7 @@ textarea[class*='bg-background']:focus {
   position: fixed !important;
   top: 0 !important;
   left: 0 !important;
-  z-index: 9999 !important;
+  z-index: var(--z-popover) !important;
   pointer-events: none !important;
 }
 
@@ -1049,6 +1053,12 @@ div[class*='text-xs'][class*='inline-flex'][class*='items-center'][class*='gap-2
 /* =============================== */
 
 /* Estilos padrão para elementos de filtro e cards admin */
+.filter-container,
+.admin-filter-card {
+  position: relative;
+  z-index: 1;
+}
+
 .admin-filter-element {
   border-color: rgb(229 231 235) !important; /* border-gray-200 */
   transition: all 0.2s ease-in-out !important;

--- a/components/admin/admin-filter-card.tsx
+++ b/components/admin/admin-filter-card.tsx
@@ -60,7 +60,7 @@ export function AdminFilterCard({
   return (
     <Card
       className={cn(
-        'relative overflow-visible border-0 shadow-xl bg-white backdrop-blur-sm transition-all duration-300',
+        'admin-filter-card relative overflow-visible border-0 shadow-xl bg-white backdrop-blur-sm transition-all duration-300',
         className
       )}
     >

--- a/components/ui/custom-select.tsx
+++ b/components/ui/custom-select.tsx
@@ -146,7 +146,7 @@ export function CustomSelect({
         {isOpen && (
           <div
             id="dropdown-content"
-            className="absolute z-[9999] mt-1 w-full rounded-md border bg-white shadow-xl animate-in fade-in-0 zoom-in-95 slide-in-from-top-2 overflow-hidden"
+            className="absolute z-[var(--z-dropdown)] mt-1 w-full rounded-md border bg-white shadow-xl animate-in fade-in-0 zoom-in-95 slide-in-from-top-2 overflow-hidden"
             style={{
               maxHeight: '300px',
             }}

--- a/components/ui/filter-select-group.tsx
+++ b/components/ui/filter-select-group.tsx
@@ -28,7 +28,7 @@ export function FilterSelectGroup({
   return (
     <div
       className={cn(
-        'flex items-center flex-wrap flex-1',
+        'flex items-center flex-wrap flex-1 filter-container',
         gapClasses[gap],
         className
       )}

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -75,7 +75,7 @@ const SelectContent = React.forwardRef<
     <SelectPrimitive.Content
       ref={ref}
       className={cn(
-        'relative z-[9999] max-h-96 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+        'relative z-[var(--z-dropdown)] max-h-96 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
         position === 'popper' &&
           'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
         className


### PR DESCRIPTION
## Objetivo
- padronizar z-index dos dropdowns e modais de filtro garantindo que sobreponham outros elementos

## Como testar
- `pnpm format:check`
- `pnpm lint`
- `pnpm test`
- acessar páginas de admin com filtros e confirmar que os dropdowns aparecem acima dos demais elementos

## Checklist
- [ ] Código limpo
- [ ] Testes passando
- [ ] Sem alteração de design
- [ ] Foco azul (`focus:border-blue-500` ou `focus:outline-blue-500`)

------
https://chatgpt.com/codex/tasks/task_e_689a637b0c388330a1ce4982f74d9d0a